### PR TITLE
docs: Fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ## Getting started
 
 ```sh
-npm install --save-dev @commitlint/{angular,cli}
+npm install --save-dev @commitlint/{config-angular,cli}
 echo "module.exports = {extends: ['@commitlint/config-angular']}" > commitlint.config.js
 ```
 


### PR DESCRIPTION
Fixes the error:

```bash
➜ npm install --save-dev @commitlint/{angular,cli}
npm ERR! code E404
npm ERR! 404 Not Found: @commitlint/angular@latest

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/okonet/.npm/_logs/2017-07-27T09_27_59_210Z-debug.log
```