### PR TITLE
feat(core): add Signed-off-by rule

### DIFF
--- a/@commitlint/core/src/rules/index.js
+++ b/@commitlint/core/src/rules/index.js
@@ -18,6 +18,7 @@ export default {
 	'scope-enum': require('./scope-enum'),
 	'scope-max-length': require('./scope-max-length'),
 	'scope-min-length': require('./scope-min-length'),
+	'signed-off-by': require('./signed-off-by'),
 	'subject-case': require('./subject-case'),
 	'subject-empty': require('./subject-empty'),
 	'subject-full-stop': require('./subject-full-stop'),

--- a/@commitlint/core/src/rules/signed-off-by.js
+++ b/@commitlint/core/src/rules/signed-off-by.js
@@ -1,0 +1,13 @@
+export default (parsed, when, value) => {
+	const input = /.*\n(Signed-off-by:).*\n+/g.exec(parsed.raw);
+
+	const negated = when === 'never';
+	const hasSignedOffBy = Boolean(input && input[1] === value);
+
+	return [
+		negated ? !hasSignedOffBy : hasSignedOffBy,
+		['message', negated ? 'must not' : 'must', 'be signed off']
+			.filter(Boolean)
+			.join(' ')
+	];
+};

--- a/@commitlint/core/src/rules/signed-off-by.test.js
+++ b/@commitlint/core/src/rules/signed-off-by.test.js
@@ -1,0 +1,79 @@
+import test from 'ava';
+import parse from '../library/parse';
+import check from './signed-off-by';
+
+const messages = {
+	empty: 'chore:\n',
+	with: `chore: subject\nbody\nfooter\nSigned-off-by:\n\n`,
+	without: `chore: subject\nbody\nfooter\n\n`,
+	inSubject: `chore: subject Signed-off-by:\nbody\nfooter\n\n`,
+	inBody: `chore: subject\nbody Signed-off-by:\nfooter\n\n`
+};
+
+const parsed = {
+	empty: parse(messages.empty),
+	with: parse(messages.with),
+	without: parse(messages.without),
+	inSubject: parse(messages.inSubject),
+	inBody: parse(messages.inBody)
+};
+
+test('empty against "always signed-off-by" should fail', async t => {
+	const [actual] = check(await parsed.empty, 'always', 'Signed-off-by:');
+	const expected = false;
+	t.is(actual, expected);
+});
+
+test('empty against "never signed-off-by" should succeed', async t => {
+	const [actual] = check(await parsed.empty, 'never', 'Signed-off-by:');
+	const expected = true;
+	t.is(actual, expected);
+});
+
+test('with against "always signed-off-by" should succeed', async t => {
+	const [actual] = check(await parsed.with, 'always', 'Signed-off-by:');
+	const expected = true;
+	t.is(actual, expected);
+});
+
+test('with against "never signed-off-by" should fail', async t => {
+	const [actual] = check(await parsed.with, 'never', 'Signed-off-by:');
+	const expected = false;
+	t.is(actual, expected);
+});
+
+test('without against "always signed-off-by" should fail', async t => {
+	const [actual] = check(await parsed.without, 'always', 'Signed-off-by:');
+	const expected = false;
+	t.is(actual, expected);
+});
+
+test('without against "never signed-off-by" should succeed', async t => {
+	const [actual] = check(await parsed.without, 'never', 'Signed-off-by:');
+	const expected = true;
+	t.is(actual, expected);
+});
+
+test('inSubject against "always signed-off-by" should fail', async t => {
+	const [actual] = check(await parsed.inSubject, 'always', 'Signed-off-by:');
+	const expected = false;
+	t.is(actual, expected);
+});
+
+test('inSubject against "never signed-off-by" should succeed', async t => {
+	const [actual] = check(await parsed.inSubject, 'never', 'Signed-off-by:');
+	const expected = true;
+	t.is(actual, expected);
+});
+
+test('inBody against "always signed-off-by" should fail', async t => {
+	const [actual] = check(await parsed.inBody, 'always', 'Signed-off-by:');
+	const expected = false;
+	t.is(actual, expected);
+});
+
+test('inBody against "never signed-off-by" should succeed', async t => {
+	const [actual] = check(await parsed.inBody, 'never', 'Signed-off-by:');
+	const expected = true;
+	t.is(actual, expected);
+});

--- a/docs/reference-rules.md
+++ b/docs/reference-rules.md
@@ -263,3 +263,11 @@ Rule configurations are either of type `array` residing on a key with the rule's
 ```js
   0
 ```
+
+#### signed-off-by
+* **condition**: `message` has `value`
+* **rule**: `always`
+* **value**
+```js
+  'Signed-off-by:'
+```


### PR DESCRIPTION
Added a new rule to allow for commit messages to be validated for the `Signed-off-by:` syntax as added when doing `git commit --signoff`.

I **think** I've changed everything required for this, but please shout up if I've missed something.