### PR TITLE
feat(core): ignore version commits with footers

### DIFF
--- a/@commitlint/core/src/library/is-ignored.js
+++ b/@commitlint/core/src/library/is-ignored.js
@@ -7,7 +7,13 @@ const WILDCARDS = [
 		),
 	c => c.match(/^(R|r)evert (.*)/),
 	c => c.match(/^(fixup|squash)!/),
-	c => semver.valid(c.trim())
+	c =>
+		semver.valid(
+			c
+				.split('\n')
+				.shift()
+				.trim()
+		)
 ];
 
 export default function isIgnored(commit = '') {

--- a/@commitlint/core/src/library/is-ignored.test.js
+++ b/@commitlint/core/src/library/is-ignored.test.js
@@ -34,22 +34,38 @@ test('should return true for revert commits', t => {
 	);
 });
 
-test('should return true for npm version commits', t => {
-	t.true(isIgnored(`0.0.1`));
-	t.true(isIgnored(`0.1.0`));
-	t.true(isIgnored(`1.0.0`));
-	t.true(isIgnored(`0.0.1-alpha`));
-	t.true(isIgnored(`0.0.1-some-crazy-tag`));
-	t.true(isIgnored(`0.0.1-0`));
-	t.true(isIgnored(`0.0.1-999`));
-	t.true(isIgnored(`0.0.1-alpha.0`));
-	t.true(isIgnored(`0.0.1-alpha.999`));
-	t.true(isIgnored(`0.0.1-some-crazy-tag.0`));
-	t.true(isIgnored(`0.0.1-some-crazy-tag.999`));
-	t.true(isIgnored(`0.0.1-1e69d54`));
-	t.true(isIgnored(`v0.0.1`));
-	t.true(isIgnored(` v3.0.0`));
-});
+const versionCommitInputs = [
+	'0.0.1',
+	'0.1.0',
+	'1.0.0',
+	'0.0.1-alpha',
+	'0.0.1-some-crazy-tag',
+	'0.0.1-0',
+	'0.0.1-999',
+	'0.0.1-alpha.0',
+	'0.0.1-alpha.999',
+	'0.0.1-some-crazy-tag.0',
+	'0.0.1-some-crazy-tag.999',
+	'0.0.1-1e69d54',
+	'v0.0.1',
+	' v3.0.0'
+];
+for (let i = 0, len = versionCommitInputs.length; i < len; i++) {
+	const input = versionCommitInputs[i];
+	const commitMsg1 = input;
+	const commitMsg2 = `${input}\n\nSigned-off-by: Developer <example@example.com>`;
+	const commitMsg3 = `${input}\n\nChange-Id: I895114872a515a269487a683124b63303818e19c`;
+	const commitMsg4 = `${input}\n\nSigned-off-by: Developer <example@example.com>\nChange-Id: I895114872a515a269487a683124b63303818e19c`;
+
+	console.log(commitMsg1, commitMsg2, commitMsg3, commitMsg4);
+
+	test(`should return true for version commit permutations of '${input}'`, t => {
+		t.true(isIgnored(commitMsg1));
+		t.true(isIgnored(commitMsg2));
+		t.true(isIgnored(commitMsg3));
+		t.true(isIgnored(commitMsg4));
+	});
+}
 
 test('should return true fixup commits', t => {
 	t.true(isIgnored('fixup! initial commit'));

--- a/@commitlint/core/src/library/is-ignored.test.js
+++ b/@commitlint/core/src/library/is-ignored.test.js
@@ -1,6 +1,36 @@
 import test from 'ava';
 import isIgnored from './is-ignored';
 
+const VERSION_MESSAGES = [
+	'0.0.1',
+	'0.1.0',
+	'1.0.0',
+	'0.0.1-alpha',
+	'0.0.1-some-crazy-tag',
+	'0.0.1-0',
+	'0.0.1-999',
+	'0.0.1-alpha.0',
+	'0.0.1-alpha.999',
+	'0.0.1-some-crazy-tag.0',
+	'0.0.1-some-crazy-tag.999',
+	'0.0.1-1e69d54',
+	'v0.0.1',
+	' v3.0.0'
+];
+
+const AMENDMENTS = [
+	'Signed-off-by: Developer <example@example.com>',
+	'Change-Id: I895114872a515a269487a683124b63303818e19c',
+	'Signed-off-by: Developer <example@example.com>\nChange-Id: I895114872a515a269487a683124b63303818e19c'
+];
+
+const AMENDED_VERSION_MESSAGES = VERSION_MESSAGES.reduce((results, message) => {
+	return [
+		...results,
+		...AMENDMENTS.map(amendment => `${message}\n\n${amendment}`)
+	];
+}, []);
+
 test('should return false when called without arguments', t => {
 	t.false(isIgnored());
 });
@@ -13,7 +43,7 @@ test('should return false for normal commit', t => {
 	t.false(isIgnored('initial commit'));
 });
 
-test('should return false for branch merges', t => {
+test('should return true for branch merges', t => {
 	t.true(isIgnored("Merge branch 'iss53'"));
 });
 
@@ -34,38 +64,13 @@ test('should return true for revert commits', t => {
 	);
 });
 
-const versionCommitInputs = [
-	'0.0.1',
-	'0.1.0',
-	'1.0.0',
-	'0.0.1-alpha',
-	'0.0.1-some-crazy-tag',
-	'0.0.1-0',
-	'0.0.1-999',
-	'0.0.1-alpha.0',
-	'0.0.1-alpha.999',
-	'0.0.1-some-crazy-tag.0',
-	'0.0.1-some-crazy-tag.999',
-	'0.0.1-1e69d54',
-	'v0.0.1',
-	' v3.0.0'
-];
-for (let i = 0, len = versionCommitInputs.length; i < len; i++) {
-	const input = versionCommitInputs[i];
-	const commitMsg1 = input;
-	const commitMsg2 = `${input}\n\nSigned-off-by: Developer <example@example.com>`;
-	const commitMsg3 = `${input}\n\nChange-Id: I895114872a515a269487a683124b63303818e19c`;
-	const commitMsg4 = `${input}\n\nSigned-off-by: Developer <example@example.com>\nChange-Id: I895114872a515a269487a683124b63303818e19c`;
+test('should ignore npm semver commits', t => {
+	VERSION_MESSAGES.forEach(message => t.true(isIgnored(message)));
+});
 
-	console.log(commitMsg1, commitMsg2, commitMsg3, commitMsg4);
-
-	test(`should return true for version commit permutations of '${input}'`, t => {
-		t.true(isIgnored(commitMsg1));
-		t.true(isIgnored(commitMsg2));
-		t.true(isIgnored(commitMsg3));
-		t.true(isIgnored(commitMsg4));
-	});
-}
+test('should ignore npm semver commits with footers', t => {
+	AMENDED_VERSION_MESSAGES.forEach(message => t.true(isIgnored(message)));
+});
 
 test('should return true fixup commits', t => {
 	t.true(isIgnored('fixup! initial commit'));


### PR DESCRIPTION
**Edit** by @marionebl:

* Add support for version commits with footers, e.g. as produced by `--sign-off` or Gerrit.
* Add relevant test cases