### PR TITLE
Fixes the guides-local-setup link in the docs README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -54,7 +54,7 @@ commitlint --from=HEAD~1
 ```
 
 
-?> To get the most out of `commitlint` you'll want to automate it in your project lifecycle. See our [Local setup guide](./guides-local-setup?id=guide-local-setup) for next steps.
+?> To get the most out of `commitlint` you'll want to automate it in your project lifecycle. See our [Local setup guide](./guides-local-setup.md?id=guides-local-setup) for next steps.
 
 ## Documentation
 


### PR DESCRIPTION
Added a missing `.md` extension to the guides-local-setup link in the docs README