### PR TITLE
feat: add references-empty rule

### DIFF
--- a/@commitlint/core/src/rules/index.js
+++ b/@commitlint/core/src/rules/index.js
@@ -13,6 +13,7 @@ export default {
 	'header-max-length': require('./header-max-length'),
 	'header-min-length': require('./header-min-length'),
 	lang: require('./lang'),
+	'references-empty': require('./references-empty'),
 	'scope-case': require('./scope-case'),
 	'scope-empty': require('./scope-empty'),
 	'scope-enum': require('./scope-enum'),

--- a/@commitlint/core/src/rules/references-empty.js
+++ b/@commitlint/core/src/rules/references-empty.js
@@ -1,0 +1,10 @@
+import message from '../library/message';
+
+export default (parsed, when = 'never') => {
+	const negated = when === 'always';
+	const notEmpty = parsed.references.length > 0;
+	return [
+		negated ? !notEmpty : notEmpty,
+		message(['references', negated ? 'must' : 'may not', 'be empty'])
+	];
+};

--- a/@commitlint/core/src/rules/references-empty.test.js
+++ b/@commitlint/core/src/rules/references-empty.test.js
@@ -1,0 +1,65 @@
+import test from 'ava';
+import parse from '../library/parse';
+import referencesEmpty from './references-empty';
+
+const messages = {
+	plain: 'foo: bar',
+	comment: 'foo: baz\n#1 Comment',
+	reference: '#comment\nfoo: baz \nCloses #1',
+	references: '#comment\nfoo: bar \nCloses #1, #2, #3'
+};
+
+const parsed = {
+	plain: parse(messages.plain),
+	comment: parse(messages.comment),
+	reference: parse(messages.reference),
+	references: parse(messages.references)
+};
+
+test('defaults to never and fails for plain', async t => {
+	const [actual] = referencesEmpty(await parsed.plain);
+	const expected = false;
+	t.is(actual, expected);
+});
+
+test('defaults to never and succeeds for reference', async t => {
+	const [actual] = referencesEmpty(await parsed.reference);
+	const expected = true;
+	t.is(actual, expected);
+});
+
+test('fails for comment with never', async t => {
+	const [actual] = referencesEmpty(await parsed.comment, 'never');
+	const expected = false;
+	t.is(actual, expected);
+});
+
+test('succeeds for comment with always', async t => {
+	const [actual] = referencesEmpty(await parsed.comment, 'always');
+	const expected = true;
+	t.is(actual, expected);
+});
+
+test('succeeds for reference with never', async t => {
+	const [actual] = referencesEmpty(await parsed.reference, 'never');
+	const expected = true;
+	t.is(actual, expected);
+});
+
+test('fails for reference with always', async t => {
+	const [actual] = referencesEmpty(await parsed.reference, 'always');
+	const expected = false;
+	t.is(actual, expected);
+});
+
+test('succeeds for references with never', async t => {
+	const [actual] = referencesEmpty(await parsed.references, 'never');
+	const expected = true;
+	t.is(actual, expected);
+});
+
+test('fails for references with always', async t => {
+	const [actual] = referencesEmpty(await parsed.references, 'always');
+	const expected = false;
+	t.is(actual, expected);
+});

--- a/docs/reference-rules.md
+++ b/docs/reference-rules.md
@@ -90,6 +90,10 @@ Rule configurations are either of type `array` residing on a key with the rule's
   0
 ```
 
+#### references-empty
+* **condition**: `references` has at least one entry
+* **rule**: `never`
+
 #### scope-enum
 * **condition**: `scope` is found in value
 * **rule**: `always`


### PR DESCRIPTION
* allow to test for presence of references
* common use case is checking of an issue id was given
* will require parserOpts for most projects
* issue references from commit header are omitted via angular preset

* Supersedes #76 
* Closes #95