### PR TITLE
feat(patternplate): allow configuring patterns via single file

### DIFF
--- a/@commitlint/config-patternplate/README.md
+++ b/@commitlint/config-patternplate/README.md
@@ -10,6 +10,21 @@ npm install --save-dev @commitlint/config-patternplate @commitlint/cli
 echo "module.exports = {extends: ['@commitlint/config-patternplate']};" > commitlint.config.js
 ```
 
+## Configuring patterns
+
+Create a `.commitlint-patterns.json` with an array of patterns you want to use in your project:
+
+```json
+{
+  "patterns": [
+    "core",
+    "navigation"
+  ]
+}
+```
+
+Commitlint will limit the `scope` to only allow those defined, plus a catch-all "system".
+
 ## Rules
 `@commitlint/config-patternplate` extends the [shareable angular config](../config-angular#rules).
 Additionally these rules apply:

--- a/@commitlint/config-patternplate/index.js
+++ b/@commitlint/config-patternplate/index.js
@@ -1,13 +1,32 @@
 const path = require('path');
+const fs = require('fs');
 const globby = require('globby');
 const merge = require('lodash').merge;
 
 function pathToId(root, filePath) {
 	const relativePath = path.relative(root, filePath);
-	return path.dirname(relativePath).split(path.sep).join('/');
+	return path
+		.dirname(relativePath)
+		.split(path.sep)
+		.join('/');
 }
 
 function getPatternIDs() {
+	const patternsJSON = path.resolve(
+		process.cwd(),
+		'./.commitlint-patterns.json'
+	);
+
+	if (fs.existsSync(patternsJSON)) {
+		try {
+			const patterns = JSON.parse(fs.readFileSync(patternsJSON, 'utf-8'));
+			return Promise.resolve(patterns.patterns);
+		} catch (err) {
+			console.log('There was an error processing .commitlint-patterns.json');
+			console.log('Falling back to directory patterns');
+		}
+	}
+
 	const root = path.resolve(process.cwd(), './patterns');
 	const glob = path.resolve(root, '**/pattern.json');
 	return globby(glob).then(results =>


### PR DESCRIPTION
Allows configuring patterns by defining a single file at the root of the
repository. `.commitlint-patterns.json` contains an array of patterns. Fallback
to the previous method (which to be honest I do not understand at all) is
provided when there's no such file, or there's an error parsing the JSON.

Small documentation change in its README.