### PR TITLE
feat: allow extending settings via config

### DIFF
--- a/@commitlint/core/src/load.js
+++ b/@commitlint/core/src/load.js
@@ -7,7 +7,8 @@ import executeRule from './library/execute-rule';
 import resolveExtends from './library/resolve-extends';
 
 const w = (a, b) => (Array.isArray(b) ? b : undefined);
-const valid = input => pick(input, 'extends', 'rules', 'parserPreset');
+const valid = input =>
+	pick(input, 'extends', 'rules', 'settings', 'parserPreset');
 
 export default async (seed = {}, options = {cwd: process.cwd()}) => {
 	const loaded = await loadConfig(options.cwd);

--- a/@commitlint/prompt/src/input.js
+++ b/@commitlint/prompt/src/input.js
@@ -1,10 +1,11 @@
 import {load} from '@commitlint/core';
 import throat from 'throat';
+import {merge} from 'lodash';
 
 import format from './library/format';
 import getHasName from './library/get-has-name';
 import getPrompt from './library/get-prompt';
-import settings from './settings';
+import defaultSettings from './settings';
 
 export default input;
 
@@ -24,7 +25,8 @@ async function input(prompter) {
 		footer: null
 	};
 
-	const {rules} = await load();
+	const {rules, settings: configSettings} = await load();
+	const settings = merge(defaultSettings, configSettings);
 
 	await Promise.all(
 		['type', 'scope', 'subject', 'body', 'footer'].map(


### PR DESCRIPTION
Simplified usage (there's a lot more dynamic stuff on my config, so apologies for typos/syntax):

```javascript
module.exports = {
  extends: ['@commitlint/config-angular'],
  settings: {
    scope: {
      enumerables: {
         "auth": { description: "Authentication code, login, user profile, etc." },
         "settings": { description: "Settings and preferences" },
      }
    },
  },
  rules: {
    'scope-enum': () => {
      const scopes = ['auth', 'settings'];
      return [2, 'always', scopes.concat(['system'])];
    },
  },
};
```