### PR TITLE
docs: add contribution guide link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ npx yarn run build # run build tasks
 npx yarn start # run tests, again on change
 ```
 
+For more information on how to contribute please take a look at our [contribution guide](./.github/CONTRIBUTING.md).
+
 ### Publishing a release
 
 ```sh


### PR DESCRIPTION
Add a link to the readme to the contribution guide.

## Motivation and Context
I did not found the contribution guide at first, so I added a link to the readme so nobody else has to search for it longer than he should 🤓

## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
