### PR TITLE
docs: add contents list to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,23 @@
 *  📦  Share configuration via `npm`
 *  🤖  Tap into `conventional-changelog`
 
+## Contents
+
+* [Getting started](#getting-started)
+* [CLI](#cli)
+* [Config](#config)
+* [Shared configuration](#shared-configuration)
+* [API](#api)
+* [Tools](#tools)
+* [Version Support](#version-support)
+* [Related projects](#related-projects)
+* [License](#license)
+* [Development](#development)
+  * [Install and run](#install-and-run)
+  * [Publishing a release](#publishing-a-release)
+
+* * *
+
 ## Getting started
 
 ```sh
@@ -79,7 +96,7 @@ Copyright by @marionebl. All `commitlint` packages are released under the MIT li
 
 `commitlint` is developed in a mono repository.
 
-### Getting started
+### Install and run
 
 ```sh
 git clone git@github.com:marionebl/commitlint.git


### PR DESCRIPTION
Add table of contents to readme.

## Description
To find things faster you're looking for, a table of contents can help.

## Motivation and Context
I wanted to get a quick overview of the related content in the readme, so I thought a table of contents could help.

## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
