### PR TITLE
docs: fix to correct package name (`config-conventional`)

### DIFF
--- a/@commitlint/config-conventional/README.md
+++ b/@commitlint/config-conventional/README.md
@@ -1,6 +1,6 @@
 > Lint your conventional commits
 
-# @commitlint/config-conventions
+# @commitlint/config-conventional
 
 Shareable `commitlint` config enforcing [convention commits](https://conventionalcommits.org/).
 Use with [@commitlint/cli](../cli) and [@commitlint/prompt-cli](../prompt-cli).


### PR DESCRIPTION
## Description

Fix to correct package name (maybe typo):

`@commitlint/config-conventions` => `@commitlint/config-conventional`

## Motivation and Context

Motivation to correct package documentation.

## Usage examples

N/A

## How Has This Been Tested?

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
