### PR TITLE
fix(cli): add support for GIT_PARAMS on windows. Closes #103

### DIFF
--- a/@commitlint/cli/src/cli.js
+++ b/@commitlint/cli/src/cli.js
@@ -139,11 +139,28 @@ function checkFromHistory(flags) {
 function normalizeFlags(flags) {
 	// The `edit` flag is either a boolean or a string but we are only allowed
 	// to specify one of them in minimist
+	let edit = normalizeEdit(flags.edit);
 	if (flags.edit === '') {
-		return merge({}, flags, {edit: true, e: true});
+		edit = true;
 	}
+	return merge({}, flags, {edit, e: edit});
+}
 
-	return flags;
+function normalizeEdit(edit) {
+	if (typeof edit === 'boolean') {
+		return edit;
+	}
+	if (edit === '$GIT_PARAMS' || edit === '%GIT_PARAMS%') {
+		if (!('GIT_PARAMS' in process.env)) {
+			throw new Error(
+				`Received ${
+					edit
+				} as value for -e | --edit, but GIT_PARAMS is not available globally.`
+			);
+		}
+		return process.env.GIT_PARAMS;
+	}
+	return edit;
 }
 
 function getSeed(seed) {

--- a/@commitlint/cli/src/cli.js
+++ b/@commitlint/cli/src/cli.js
@@ -139,10 +139,7 @@ function checkFromHistory(flags) {
 function normalizeFlags(flags) {
 	// The `edit` flag is either a boolean or a string but we are only allowed
 	// to specify one of them in minimist
-	let edit = normalizeEdit(flags.edit);
-	if (flags.edit === '') {
-		edit = true;
-	}
+	const edit = flags.edit === '' ? true : normalizeEdit(flags.edit);
 	return merge({}, flags, {edit, e: edit});
 }
 
@@ -150,6 +147,10 @@ function normalizeEdit(edit) {
 	if (typeof edit === 'boolean') {
 		return edit;
 	}
+	// The recommended method to specify -e with husky is commitlint -e $GIT_PARAMS
+	// This does not work properly with win32 systems, where env variable declarations
+	// use a different syntax
+	// See https://github.com/marionebl/commitlint/issues/103 for details
 	if (edit === '$GIT_PARAMS' || edit === '%GIT_PARAMS%') {
 		if (!('GIT_PARAMS' in process.env)) {
 			throw new Error(

--- a/@commitlint/cli/src/cli.test.js
+++ b/@commitlint/cli/src/cli.test.js
@@ -101,6 +101,24 @@ test('should work with husky commitmsg hook in sub packages', async () => {
 	await execa('git', ['commit', '-m', '"test: this should work"'], {cwd});
 });
 
+test('should work with husky via commitlint -e $GIT_PARAMS', async () => {
+	const cwd = await git.bootstrap('fixtures/husky/integration');
+	await writePkg({scripts: {commitmsg: `${bin} -e $GIT_PARAMS`}}, {cwd});
+
+	await execa('npm', ['install'], {cwd});
+	await execa('git', ['add', 'package.json'], {cwd});
+	await execa('git', ['commit', '-m', '"test: this should work"'], {cwd});
+});
+
+test('should work with husky via commitlint -e %GIT_PARAMS%', async () => {
+	const cwd = await git.bootstrap('fixtures/husky/integration');
+	await writePkg({scripts: {commitmsg: `${bin} -e %GIT_PARAMS%`}}, {cwd});
+
+	await execa('npm', ['install'], {cwd});
+	await execa('git', ['add', 'package.json'], {cwd});
+	await execa('git', ['commit', '-m', '"test: this should work"'], {cwd});
+});
+
 test('should pick up parser preset and fail accordingly', async t => {
 	const cwd = await git.bootstrap('fixtures/parser-preset');
 	const actual = await cli(['--parser-preset', './parser-preset'], {cwd})(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The commit adds a new special parser for the `edit` flag for Windows,
so that `$GIT_PARAMS` can be read from the command-line

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
commitlint on Windows doesn't work when `$GIT_PARAMS` are
specified in the package.json file.
<!--- If it fixes an open issue, please link to the issue here. -->
#103 

## Usage examples
<!--- Provide examples of intended usage -->

```js
// commitlint.config.js
module.exports = {
  extends: ["@commitlint/config-conventional"]
};
```

```js
// package.json
{
  ...
  "scripts": {
    "commitmsg": "commitlint -e $GIT_PARAMS"
  }
}
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
**Edit**:
- [x] new integration tests added

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
