### PR TITLE
feat(prompt): help description for chore

### DIFF
--- a/@commitlint/prompt/src/settings.js
+++ b/@commitlint/prompt/src/settings.js
@@ -9,8 +9,8 @@ export default {
 				description: 'Solves a bug.'
 			},
 			chore: {
-			  description: 'Other changes that don\'t modify src or test files',
-			}
+				description: "Other changes that don't modify src or test files"
+			},
 			docs: {
 				description: 'Adds or alters documentation.'
 			},

--- a/@commitlint/prompt/src/settings.js
+++ b/@commitlint/prompt/src/settings.js
@@ -8,6 +8,9 @@ export default {
 			fix: {
 				description: 'Solves a bug.'
 			},
+			chore: {
+			  description: 'Other changes that don\'t modify src or test files',
+			}
 			docs: {
 				description: 'Adds or alters documentation.'
 			},


### PR DESCRIPTION
Didn't include this in my latest PR since it was supposedly going away,
but since both `config-conventional` and conventionalcommits.org still have it,
at the very least fix it so it's not the only one that appears without a description
in the prompt help.