### PR TITLE
fix: fix npm semver commits with type chore not being ignored

### DIFF
--- a/@commitlint/core/src/library/is-ignored.js
+++ b/@commitlint/core/src/library/is-ignored.js
@@ -12,6 +12,7 @@ const WILDCARDS = [
 			c
 				.split('\n')
 				.shift()
+				.replace(/^chore(\([^)]+\))?:/, '')
 				.trim()
 		)
 ];

--- a/@commitlint/core/src/library/is-ignored.test.js
+++ b/@commitlint/core/src/library/is-ignored.test.js
@@ -68,6 +68,13 @@ test('should ignore npm semver commits', t => {
 	VERSION_MESSAGES.forEach(message => t.true(isIgnored(message)));
 });
 
+test('should ignore npm semver commits with chore', t => {
+	VERSION_MESSAGES.forEach(message => t.true(isIgnored(`chore: ${message}`)));
+	VERSION_MESSAGES.forEach(message =>
+		t.true(isIgnored(`chore(release): ${message}`))
+	);
+});
+
 test('should ignore npm semver commits with footers', t => {
 	AMENDED_VERSION_MESSAGES.forEach(message => t.true(isIgnored(message)));
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Added `chore: vx.x.x` to the list of ignores.

## Description

Commitlint was failing to validate the commit produced by `standard-version`.

## Motivation and Context

See #198 

## Usage examples
<!--- Provide examples of intended usage -->

```sh
echo "chore: v1.0.0" | commitlint # passes
echo "chore: 1.0.0" | commitlint # passes
echo "chore(release): v1.0.0" | commitlint # passes
echo "chore(release): 1.0.0" | commitlint # passes
```

## How Has This Been Tested?

Added the inputs above to the `is-ignored` tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
