### PR TITLE
docs: added setup instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,23 @@ npm install --save-dev @commitlint/{config-conventional,cli}
 echo "module.exports = {extends: ['@commitlint/config-conventional']}" > commitlint.config.js
 ```
 
+
+To lint commits before they are created you can use the 'commitmsg' hook as described [here](https://github.com/typicode/husky/blob/master/HOOKS.md#hooks)
+
+```json
+{
+  "scripts": {
+    "commitmsg": "commitlint -e $GIT_PARAMS"
+  }
+}
+```
+
+
+**Detailed Setup instructions**
+
 * [Local setup](http://marionebl.github.io/commitlint/#/guides-local-setup) - Lint messages on commit with husky
 * [CI setup](http://marionebl.github.io/commitlint/#/guides-ci-setup) - Lint messages during CI builds
+
 
 ## CLI
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a section under 'getting started'.  
The basic setup is now available in a code block.

## Motivation and Context
The setup was hard to find. IMHO this essential example should be shown in the readme.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
