### PR TITLE
fix: ignore branch merges with multiple newlines

### DIFF
--- a/@commitlint/is-ignored/src/index.js
+++ b/@commitlint/is-ignored/src/index.js
@@ -3,7 +3,7 @@ import semver from 'semver';
 const WILDCARDS = [
 	c =>
 		c.match(
-			/^(Merge pull request)|(Merge (.*?) into (.*?)|(Merge branch (.*?))(?:\r?\n)?$)/
+			/^(Merge pull request)|(Merge (.*?) into (.*?)|(Merge branch (.*?))(?:\r?\n)*$)/
 		),
 	c => c.match(/^(R|r)evert (.*)/),
 	c => c.match(/^(fixup|squash)!/),

--- a/@commitlint/is-ignored/src/index.test.js
+++ b/@commitlint/is-ignored/src/index.test.js
@@ -52,6 +52,11 @@ test('should return true for branch merges with newline characters', t => {
 	t.true(isIgnored("Merge branch 'ctrom-YarnBuild'\r\n"));
 });
 
+test('should return true for branch merges with multiple newline characters', t => {
+	t.true(isIgnored("Merge branch 'ctrom-YarnBuild'\n\n\n"));
+	t.true(isIgnored("Merge branch 'ctrom-YarnBuild'\r\n\r\n\r\n"));
+});
+
 test('should return true for merged PRs', t => {
 	t.true(isIgnored('Merge pull request #369'));
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Still having some issues with merge commits. Seems to be caused by merge commits occasionally having more than one newline character.