### PR TITLE
docs: use absolute URLs in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -40,7 +40,7 @@ To keep the code base of commitlint neat and tidy the following rules apply to e
 
 > Coding standards
 
-* [Happiness](/sindresorhus/xo) enforced
+* [Happiness](https://github.com/sindresorhus/xo) enforced
 * Favor micro library over swiss army knives (rimraf, ncp vs. fs-extra)
 * Be awesome
 
@@ -50,7 +50,7 @@ To make your life easier commitlint is commitizen-friendly and provides the npm 
 
 > Commit standards
 
-* [conventional-changelog](./@commitlint/prompt)
+* [conventional-changelog](https://github.com/marionebl/commitlint/tree/master/%40commitlint/prompt)
 * husky commit message hook available
 * present tense
 * maximum of 100 characters


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When clicking the original links on GitHub, I am taken to a 404 page. By using absolute GitHub URLs, clicking Happiness and conventional-changelog will navigate to the expected webpages.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Was curious about contributing to this codebase and noticed this issue when I clicked the XO link.

## Usage examples
<!--- Provide examples of intended usage -->

N/A

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

Clicking the links in the GitHub markdown preview takes me to the expected pages.

![image](https://user-images.githubusercontent.com/2344137/35360993-a79a6496-012d-11e8-9e05-b382db4ce49b.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
