### PR TITLE
fix(parse): default to angular preset for empty parserOpts

### DIFF
--- a/@commitlint/parse/src/index.js
+++ b/@commitlint/parse/src/index.js
@@ -4,7 +4,7 @@ import defaultChangelogOpts from 'conventional-changelog-angular';
 export default parse;
 
 async function parse(message, parser = sync, parserOpts) {
-	if (!parserOpts) {
+	if (!parserOpts || Object.keys(parserOpts || {}).length === 0) {
 		const changelogOpts = await defaultChangelogOpts;
 		parserOpts = changelogOpts.parserOpts;
 	}

--- a/@commitlint/parse/src/index.test.js
+++ b/@commitlint/parse/src/index.test.js
@@ -105,6 +105,13 @@ test('supports scopes with /', async t => {
 	t.is(actual.subject, 'subject');
 });
 
+test('supports scopes with / and empty parserOpts', async t => {
+	const message = 'type(some/scope): subject';
+	const actual = await parse(message, undefined, {});
+	t.is(actual.scope, 'some/scope');
+	t.is(actual.subject, 'subject');
+});
+
 test('ignores comments', async t => {
 	const message = 'type(some/scope): subject\n# some comment';
 	const changelogOpts = await importFrom(


### PR DESCRIPTION


Changes `parse` to default to `conventional-changelog-angular` for empty objects. Previously only `falsy` values triggered the default.

## Motivation and Context

* Closes #262 

## How Has This Been Tested?

* New unit test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
