### PR TITLE
docs: update teaser for core packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ A number of shared configurations are available to install and use with `commitl
 ## API
 
 * Alternative, programatic way to interact with `commitlint`
-* `npm install --save @commitlint/core`
+* `npm install --save-dev @commitlint/core`
 * Packages: [core](./@commitlint/core)
 * See [API](./docs/reference-api.md) for a complete list of methods and examples
 

--- a/README.md
+++ b/README.md
@@ -91,8 +91,11 @@ A number of shared configurations are available to install and use with `commitl
 ## API
 
 * Alternative, programatic way to interact with `commitlint`
-* `npm install --save-dev @commitlint/core`
-* Packages: [core](./@commitlint/core)
+* Packages: 
+  * [format](./@commitlint/format) - Format commitlint reports
+  * [lint](./@commitlint/lint) - Lint a string against commitlint rules
+  * [load](./@commitlint/load) - Load shared commitlint configuration
+  * [read](./@commitlint/read) - Read commit messages from a specified range or last edit
 * See [API](./docs/reference-api.md) for a complete list of methods and examples
 
 ## Tools


### PR DESCRIPTION
Instead of `--save` use `--save-dev` to align with other examples in the `README.md`.  
If this was intended then just ignore this.

## Motivation and Context
Alignment with other things only. Not an issue.

