### PR TITLE
feat: add bitbucket merge commits to ignore list

### DIFF
--- a/@commitlint/is-ignored/src/index.js
+++ b/@commitlint/is-ignored/src/index.js
@@ -14,7 +14,8 @@ const WILDCARDS = [
 				.shift()
 				.replace(/^chore(\([^)]+\))?:/, '')
 				.trim()
-		)
+		),
+	c => c.match(/^Merged (.*?)(in|into) (.*)/)
 ];
 
 export default function isIgnored(commit = '') {

--- a/@commitlint/is-ignored/src/index.test.js
+++ b/@commitlint/is-ignored/src/index.test.js
@@ -96,3 +96,10 @@ test('should return true fixup commits', t => {
 test('should return true squash commits', t => {
 	t.true(isIgnored('squash! initial commit'));
 });
+
+test('should return true for bitbucket merge commits', t => {
+	t.true(
+		isIgnored('Merged in feature/facebook-friends-sync (pull request #8)')
+	);
+	t.true(isIgnored('Merged develop into feature/component-form-select-card'));
+});


### PR DESCRIPTION
This PR is related to issue #60 and [this comment](https://github.com/marionebl/commitlint/issues/60#issuecomment-369888823).

## Description
This adds two types of Bitbucket merge commits to the ignore list, which are generated by Bitbucket itself. It should allow all Bitbucket users to use the default message without the linter going berserk on these messages.

## Motivation and Context
We at [Peakfijn](https://peakfijn.nl) definitely want to use this tool. But since we are using Bitbucket all of our projects raises false positives on the default merge messages.

## Usage examples
The following commands should now pass without failing.

```sh
$ echo "Merged in feature/facebook-friends-sync (pull request #8)" | commitlint
$ echo "Merged develop into feature/component-form-select-card" | commitlint
```

## How Has This Been Tested?
I added these exact messages to the test file with a proper description about Bitbucket.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [X] All new and existing tests passed.
