### PR TITLE
feat(rules): support array for scope-case and type-case

### DIFF
--- a/@commitlint/rules/src/scope-case.test.js
+++ b/@commitlint/rules/src/scope-case.test.js
@@ -248,8 +248,63 @@ test('with uppercase scope should fail for "never uppercase"', async t => {
 	t.is(actual, expected);
 });
 
-test('with lowercase scope should succeed for "always uppercase"', async t => {
+test('with uppercase scope should succeed for "always uppercase"', async t => {
 	const [actual] = scopeCase(await parsed.uppercase, 'always', 'uppercase');
 	const expected = true;
+	t.is(actual, expected);
+});
+
+test('with uppercase scope should succeed for "always [uppercase, lowercase]"', async t => {
+	const [actual] = scopeCase(await parsed.uppercase, 'always', [
+		'uppercase',
+		'lowercase'
+	]);
+	const expected = true;
+	t.is(actual, expected);
+});
+
+test('with lowercase scope should succeed for "always [uppercase, lowercase]"', async t => {
+	const [actual] = scopeCase(await parsed.lowercase, 'always', [
+		'uppercase',
+		'lowercase'
+	]);
+	const expected = true;
+	t.is(actual, expected);
+});
+
+test('with mixedcase scope should fail for "always [uppercase, lowercase]"', async t => {
+	const [actual] = scopeCase(await parsed.mixedcase, 'always', [
+		'uppercase',
+		'lowercase'
+	]);
+	const expected = false;
+	t.is(actual, expected);
+});
+
+test('with mixedcase scope should pass for "always [uppercase, lowercase, camel-case]"', async t => {
+	const [actual] = scopeCase(await parsed.mixedcase, 'always', [
+		'uppercase',
+		'lowercase',
+		'camel-case'
+	]);
+	const expected = true;
+	t.is(actual, expected);
+});
+
+test('with mixedcase scope should pass for "never [uppercase, lowercase]"', async t => {
+	const [actual] = scopeCase(await parsed.mixedcase, 'never', [
+		'uppercase',
+		'lowercase'
+	]);
+	const expected = true;
+	t.is(actual, expected);
+});
+
+test('with uppercase scope should fail for "never [uppercase, lowercase]"', async t => {
+	const [actual] = scopeCase(await parsed.uppercase, 'never', [
+		'uppercase',
+		'lowercase'
+	]);
+	const expected = false;
 	t.is(actual, expected);
 });

--- a/@commitlint/rules/src/subject-case.test.js
+++ b/@commitlint/rules/src/subject-case.test.js
@@ -269,3 +269,58 @@ test('should use expected message with "never"', async t => {
 	);
 	t.true(message.indexOf('must not be upper-case') > -1);
 });
+
+test('with uppercase scope should succeed for "always [uppercase, lowercase]"', async t => {
+	const [actual] = subjectCase(await parsed.uppercase, 'always', [
+		'uppercase',
+		'lowercase'
+	]);
+	const expected = true;
+	t.is(actual, expected);
+});
+
+test('with lowercase subject should succeed for "always [uppercase, lowercase]"', async t => {
+	const [actual] = subjectCase(await parsed.lowercase, 'always', [
+		'uppercase',
+		'lowercase'
+	]);
+	const expected = true;
+	t.is(actual, expected);
+});
+
+test('with mixedcase subject should fail for "always [uppercase, lowercase]"', async t => {
+	const [actual] = subjectCase(await parsed.mixedcase, 'always', [
+		'uppercase',
+		'lowercase'
+	]);
+	const expected = false;
+	t.is(actual, expected);
+});
+
+test('with mixedcase subject should pass for "always [uppercase, lowercase, camel-case]"', async t => {
+	const [actual] = subjectCase(await parsed.mixedcase, 'always', [
+		'uppercase',
+		'lowercase',
+		'camel-case'
+	]);
+	const expected = true;
+	t.is(actual, expected);
+});
+
+test('with mixedcase scope should pass for "never [uppercase, lowercase]"', async t => {
+	const [actual] = subjectCase(await parsed.mixedcase, 'never', [
+		'uppercase',
+		'lowercase'
+	]);
+	const expected = true;
+	t.is(actual, expected);
+});
+
+test('with uppercase scope should fail for "never [uppercase, lowercase]"', async t => {
+	const [actual] = subjectCase(await parsed.uppercase, 'never', [
+		'uppercase',
+		'lowercase'
+	]);
+	const expected = false;
+	t.is(actual, expected);
+});

--- a/@commitlint/rules/src/type-case.js
+++ b/@commitlint/rules/src/type-case.js
@@ -1,6 +1,8 @@
 import * as ensure from '@commitlint/ensure';
 import message from '@commitlint/message';
 
+const negated = when => when === 'never';
+
 export default (parsed, when, value) => {
 	const {type} = parsed;
 
@@ -8,11 +10,25 @@ export default (parsed, when, value) => {
 		return [true];
 	}
 
-	const negated = when === 'never';
+	const checks = (Array.isArray(value) ? value : [value]).map(check => {
+		if (typeof check === 'string') {
+			return {
+				when: 'always',
+				case: check
+			};
+		}
+		return check;
+	});
 
-	const result = ensure.case(type, value);
+	const result = checks.some(check => {
+		const r = ensure.case(type, check.case);
+		return negated(check.when) ? !r : r;
+	});
+
+	const list = checks.map(c => c.case).join(', ');
+
 	return [
-		negated ? !result : result,
-		message([`type must`, negated ? `not` : null, `be ${value}`])
+		negated(when) ? !result : result,
+		message([`type must`, negated(when) ? `not` : null, `be ${list}`])
 	];
 };

--- a/@commitlint/rules/src/type-case.test.js
+++ b/@commitlint/rules/src/type-case.test.js
@@ -268,3 +268,58 @@ test('with startcase type should succeed for "always startcase"', async t => {
 	const expected = true;
 	t.is(actual, expected);
 });
+
+test('with uppercase scope should succeed for "always [uppercase, lowercase]"', async t => {
+	const [actual] = typeCase(await parsed.uppercase, 'always', [
+		'uppercase',
+		'lowercase'
+	]);
+	const expected = true;
+	t.is(actual, expected);
+});
+
+test('with lowercase subject should succeed for "always [uppercase, lowercase]"', async t => {
+	const [actual] = typeCase(await parsed.lowercase, 'always', [
+		'uppercase',
+		'lowercase'
+	]);
+	const expected = true;
+	t.is(actual, expected);
+});
+
+test('with mixedcase subject should fail for "always [uppercase, lowercase]"', async t => {
+	const [actual] = typeCase(await parsed.mixedcase, 'always', [
+		'uppercase',
+		'lowercase'
+	]);
+	const expected = false;
+	t.is(actual, expected);
+});
+
+test('with mixedcase subject should pass for "always [uppercase, lowercase, camel-case]"', async t => {
+	const [actual] = typeCase(await parsed.mixedcase, 'always', [
+		'uppercase',
+		'lowercase',
+		'camel-case'
+	]);
+	const expected = true;
+	t.is(actual, expected);
+});
+
+test('with mixedcase scope should pass for "never [uppercase, lowercase]"', async t => {
+	const [actual] = typeCase(await parsed.mixedcase, 'never', [
+		'uppercase',
+		'lowercase'
+	]);
+	const expected = true;
+	t.is(actual, expected);
+});
+
+test('with uppercase scope should fail for "never [uppercase, lowercase]"', async t => {
+	const [actual] = typeCase(await parsed.uppercase, 'never', [
+		'uppercase',
+		'lowercase'
+	]);
+	const expected = false;
+	t.is(actual, expected);
+});


### PR DESCRIPTION
## Description

I've changed the scope-case and type-case rules to follow the same option for providing arrays in the rule value as is used in subject-case. Additionally, I've added tests to all 3 rules to check for this use case.

## Motivation and Context
As outlined in #307 it's really useful to be able to use a mixture of scope casing types when you use file/folder names as the scope.

## Usage examples
This is my specific use case.

```js
// commitlint.config.js
module.exports = {
  extends: ['@commitlint/config-conventional'],
  rules: {
    'scope-case': [2, 'always', ['camel-case', 'pascal-case', 'lower-case']]
  }
};
```

```sh
echo "fix(someFunctionUtil): " | commitlint # passes
echo "fix(ReactComponent): " | commitlint # passes
echo "fix(ERROR): " | commitlint # fails
```

## How Has This Been Tested?
Added test suites that passed under subject-case, then copy/tweaked them to the other files to check that they all worked in the same way.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation. (Does this need documentation? or is the subject-case docs missing this feature?)
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
