### PR TITLE
fix(platform): windows installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@
 ```sh
 # Install commitlint cli and angular config
 npm install --save-dev @commitlint/{config-conventional,cli}
+# For Windows:
+npm install --save-dev @commitlint/config-conventional @commitlint/cli
 
 # Configure commitlint to use angular config
 echo "module.exports = {extends: ['@commitlint/config-conventional']}" > commitlint.config.js


### PR DESCRIPTION
### 1. Summary

Fix installation syntax for Windows.

Curly braces syntax [**doesn't work**](https://stackoverflow.com/a/38876970/5951529) for Windows-specific terminals.

### 2. Behavior before pull request

```node
D:\SashaDemoRepositories\SashaCommitlint>npm install --save-dev @commitlint/{config-conventional,cli}
npm ERR! code ENOLOCAL
npm ERR! Could not install from "@commitlint\{config-conventional,cli}" as it does not contain a package.json file.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\SashaChernykh\AppData\Roaming\npm-cache\_logs\2018-04-10T13_23_19_766Z-debug.log
```

### 3. Behavior after pull request

```node
D:\SashaDemoRepositories\SashaCommitlint>npm install --save-dev @commitlint/config-conventional @commitlint/cli

+ @commitlint/config-conventional@6.1.3
+ @commitlint/cli@6.1.3
added 170 packages from 61 contributors in 34.977s
```

### 4. Testing environment

+ Windows 10 Enterprise LTSB 64-bit EN,
+ Node.js 9.11.1,
+ npm 5.8.0,
+ [**Clink**](https://mridgers.github.io/clink/) 0.4.8.

Thanks.