### PR TITLE
fix: support any case in single, double and back quotes

### DIFF
--- a/@commitlint/ensure/src/case.js
+++ b/@commitlint/ensure/src/case.js
@@ -7,7 +7,11 @@ import startCase from 'lodash.startcase';
 export default ensureCase;
 
 function ensureCase(raw = '', target = 'lowercase') {
-	const input = String(raw);
+	// We delete any content together with quotes because he can contains proper names (example `refactor: `Eslint` configuration`).
+	// We need trim string because content with quotes can be at the beginning or end of a line
+	const input = String(raw)
+		.replace(/`.*?`|".*?"|'.*?'/g, '')
+		.trim();
 	const transformed = toCase(input, target);
 
 	if (transformed === '') {

--- a/@commitlint/ensure/src/case.test.js
+++ b/@commitlint/ensure/src/case.test.js
@@ -106,11 +106,188 @@ test('true for * on snake-case', t => {
 });
 
 test('true for * on pascal-case', t => {
-	const actual = ensure('*', 'snake-case');
+	const actual = ensure('*', 'pascal-case');
 	t.is(actual, true);
 });
 
 test('true for * on start-case', t => {
-	const actual = ensure('*', 'snake-case');
+	const actual = ensure('*', 'start-case');
 	t.is(actual, true);
+});
+
+test('true for `Any_CASE_iN_back-quotes` on lowercase', t => {
+	const actual = ensure('`Any_CASE_iN_back-quotes`', 'lowercase');
+	t.is(actual, true);
+});
+
+test('true for `Any_CASE_iN_back-quotes` on uppercase', t => {
+	const actual = ensure('`Any_CASE_iN_back-quotes`', 'uppercase');
+	t.is(actual, true);
+});
+
+test('true for `Any_CASE_iN_back-quotes` on sentence-case', t => {
+	const actual = ensure('`Any_CASE_iN_back-quotes`', 'sentence-case');
+	t.is(actual, true);
+});
+
+test('true for `Any_CASE_iN_back-quotes` on camel-case', t => {
+	const actual = ensure('`Any_CASE_iN_back-quotes`', 'camel-case');
+	t.is(actual, true);
+});
+
+test('true for `Any_CASE_iN_back-quotes` on kebab-case', t => {
+	const actual = ensure('`Any_CASE_iN_back-quotes`', 'kebab-case');
+	t.is(actual, true);
+});
+
+test('true for `Any_CASE_iN_back-quotes` on snake-case', t => {
+	const actual = ensure('`Any_CASE_iN_back-quotes`', 'snake-case');
+	t.is(actual, true);
+});
+
+test('true for `Any_CASE_iN_back-quotes` on pascal-case', t => {
+	const actual = ensure('`Any_CASE_iN_back-quotes`', 'pascal-case');
+	t.is(actual, true);
+});
+
+test('true for `Any_CASE_iN_back-quotes` on start-case', t => {
+	const actual = ensure('`Any_CASE_iN_back-quotes`', 'start-case');
+	t.is(actual, true);
+});
+
+test('true for lowercase `Any_CASE_iN_back-quotes` lowercase on lowercase', t => {
+	const actual = ensure(
+		'lowercase `Any_CASE_iN_back-quotes` lowercase',
+		'lowercase'
+	);
+	t.is(actual, true);
+});
+
+test('false for UPPERCASE `Any_CASE_iN_back-quotes` UPPERCASE on lowercase', t => {
+	const actual = ensure(
+		'UPPERCASE `Any_CASE_iN_back-quotes` UPPERCASE',
+		'lowercase'
+	);
+	t.is(actual, false);
+});
+
+test('true for UPPERCASE `Any_CASE_iN_back-quotes` UPPERCASE on uppercase', t => {
+	const actual = ensure(
+		'UPPERCASE `Any_CASE_iN_back-quotes` UPPERCASE',
+		'uppercase'
+	);
+	t.is(actual, true);
+});
+
+test('false for lowercase `Any_CASE_iN_back-quotes` lowercase on uppercase', t => {
+	const actual = ensure(
+		'lowercase `Any_CASE_iN_back-quotes` lowercase',
+		'uppercase'
+	);
+	t.is(actual, false);
+});
+
+test('true for fooBar`Any_CASE_iN_back-quotes`fooBar on camel-case', t => {
+	const actual = ensure('fooBar`Any_CASE_iN_back-quotes`fooBar', 'camel-case');
+	t.is(actual, true);
+});
+
+test('false for Foo Bar`Any_CASE_iN_back-quotes` Foo Bar on camel-case', t => {
+	const actual = ensure(
+		'Foo Bar`Any_CASE_iN_back-quotes` Foo Bar',
+		'camel-case'
+	);
+	t.is(actual, false);
+});
+
+test('true for foo-bar`Any_CASE_iN_back-quotes`foo-bar on kebab-case', t => {
+	const actual = ensure(
+		'foo-bar`Any_CASE_iN_back-quotes`foo-bar',
+		'kebab-case'
+	);
+	t.is(actual, true);
+});
+
+test('false for Foo Bar `Any_CASE_iN_back-quotes` Foo Bar on kebab-case', t => {
+	const actual = ensure(
+		'Foo Bar `Any_CASE_iN_back-quotes` Foo Bar',
+		'kebab-case'
+	);
+	t.is(actual, false);
+});
+
+test('true for foo_bar`Any_CASE_iN_back-quotes`foo_bar on snake-case', t => {
+	const actual = ensure(
+		'foo_bar`Any_CASE_iN_back-quotes`foo_bar',
+		'snake-case'
+	);
+	t.is(actual, true);
+});
+
+test('false for Foo Bar `Any_CASE_iN_back-quotes` Foo Bar on snake-case', t => {
+	const actual = ensure(
+		'Foo Bar `Any_CASE_iN_back-quotes` Foo Bar',
+		'snake-case'
+	);
+	t.is(actual, false);
+});
+
+test('true for PascalCase`Any_CASE_iN_back-quotes`PascalCase on pascal-case', t => {
+	const actual = ensure(
+		'PascalCase`Any_CASE_iN_back-quotes`PascalCase',
+		'pascal-case'
+	);
+	t.is(actual, true);
+});
+
+test('false for Foo Bar `Any_CASE_iN_back-quotes` Foo Bar on pascal-case', t => {
+	const actual = ensure(
+		'Foo Bar `Any_CASE_iN_back-quotes` Foo Bar',
+		'pascal-case'
+	);
+	t.is(actual, false);
+});
+
+test('true for Foo Bar`Any_CASE_iN_back-quotes` Foo Bar on start-case', t => {
+	const actual = ensure(
+		'Foo Bar `Any_CASE_iN_back-quotes`Foo Bar',
+		'start-case'
+	);
+	t.is(actual, true);
+});
+
+test('false for foo_bar`Any_CASE_iN_back-quotes`foo_bar on start-case', t => {
+	const actual = ensure(
+		'foo_bar`Any_CASE_iN_back-quotes`foo_bar',
+		'start-case'
+	);
+	t.is(actual, false);
+});
+
+test('true for lowercase `Any_CASE_iN_back-quotes` `Any_CASE_iN_back-quotes` lowercase on lowercase', t => {
+	const actual = ensure(
+		'lowercase `Any_CASE_iN_back-quotes` `Any_CASE_iN_back-quotes` lowercase',
+		'lowercase'
+	);
+	t.is(actual, true);
+});
+
+test("true for 'Any_CASE_iN_single-quotes' on lowercase", t => {
+	const actual = ensure("'Any_CASE_iN_single-quotes'", 'lowercase');
+	t.is(actual, true);
+});
+
+test('true for "Any_CASE_iN_double-quotes" on lowercase', t => {
+	const actual = ensure('"Any_CASE_iN_double-quotes"', 'lowercase');
+	t.is(actual, true);
+});
+
+test('true for `lowercasel"\'` on lowercase', t => {
+	const actual = ensure('`lowercasel"\'`', 'lowercase');
+	t.is(actual, true);
+});
+
+test('false for `LOWERCASE on lowercase', t => {
+	const actual = ensure('`LOWERCASE', 'lowercase');
+	t.is(actual, false);
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

fixes #317

## Motivation and Context

In single, double and back quests uses own names (i.e. name of packages, technologies and etc, example `Less`, `SCSS` and etc) and it is break commit linting

## Usage examples
<!--- Provide examples of intended usage -->

```js
// commitlint.config.js
module.exports = { extends: ["@commitlint/config-conventional"] };
```

```sh
echo "fix(docs): use `WordPress` instead `wordpress`" | commitlint # fails
```

## How Has This Been Tested?

write tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
