### PR TITLE
docs(cli): added --config flag

### DIFF
--- a/docs/reference-cli.md
+++ b/docs/reference-cli.md
@@ -10,6 +10,7 @@ commitlint@4.2.0 - Lint your commit messages
   --cwd, -d              directory to execute in, defaults to: /Users/marneb/Documents/oss/commitlint
   --edit, -e             read last commit message from the specified file or fallbacks to ./.git/COMMIT_EDITMSG
   --extends, -x          array of shareable configurations to extend
+  --config, -g           path to a custom configuration
   --from, -f             lower end of the commit range to lint; applies if edit=false
   --to, -t               upper end of the commit range to lint; applies if edit=false
   --quiet, -q            toggle console output


### PR DESCRIPTION
Referencing this PR: https://github.com/marionebl/commitlint/pull/261 , I updated the docs to include `--config / -g` flag for passing a custom configuration.
http://marionebl.github.io/commitlint/#/reference-cli

## Description
Added `--config, -g` to docs.


## Motivation and Context
Greater visibility for cli options

## Usage examples
```js
// path/to/my/custom/config/commitlint.config.js 
module.exports = {
  extends: ['@commitlint/config-conventional'],
    // Disabling scope-case rule
    rules: {
      'scope-case': [0],
  }
};
```

```sh
echo "your commit message here" | commitlint --config path/to/my/custom/config/commitlint.config.js # pass
```

## How Has This Been Tested?
https://github.com/marionebl/commitlint/pull/261


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
