### PR TITLE
feat(is-ignored): added wildcard ignore for automatic merge commits

### DIFF
--- a/@commitlint/is-ignored/src/index.js
+++ b/@commitlint/is-ignored/src/index.js
@@ -15,7 +15,8 @@ const WILDCARDS = [
 				.replace(/^chore(\([^)]+\))?:/, '')
 				.trim()
 		),
-	c => c.match(/^Merged (.*?)(in|into) (.*)/)
+	c => c.match(/^Merged (.*?)(in|into) (.*)/),
+	c => c.match(/^Auto-merged (.*?) into (.*)/)
 ];
 
 export default function isIgnored(commit = '') {

--- a/@commitlint/is-ignored/src/index.test.js
+++ b/@commitlint/is-ignored/src/index.test.js
@@ -103,3 +103,7 @@ test('should return true for bitbucket merge commits', t => {
 	);
 	t.true(isIgnored('Merged develop into feature/component-form-select-card'));
 });
+
+test('should return true for automatic merge commits', t => {
+	t.true(isIgnored('Auto-merged develop into master'));
+});


### PR DESCRIPTION
## Description
[Github deployments](https://developer.github.com/v3/repos/deployments/) have an `auto_merge` parameter that "attempts to automatically merge the default branch into the requested ref, if it is behind the default branch" . 

## Motivation and Context
The automatic merge commit generated by a Github Deployment looks like `Auto-merge [branch] into [branch]` and this was failing commitlint.

## How Has This Been Tested?
See [this](https://github.com/jcarroll2007/commitlint/blob/fix/add-auto-merge-wildcard/%40commitlint/is-ignored/src/index.test.js#L107) line for the tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
