### PR TITLE
fix(cli): add environment variable cli flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To lint commits before they are created you can use the 'commitmsg' hook as desc
 ```json
 {
   "scripts": {
-    "commitmsg": "commitlint -e $GIT_PARAMS"
+    "commitmsg": "commitlint -E GIT_PARAMS"
   }
 }
 ```
@@ -92,7 +92,7 @@ A number of shared configurations are available to install and use with `commitl
 
 ## API
 
-* Alternative, programatic way to interact with `commitlint`
+* Alternative, programmatic way to interact with `commitlint`
 * Packages: 
   * [format](./@commitlint/format) - Format commitlint reports
   * [lint](./@commitlint/lint) - Lint a string against commitlint rules
@@ -111,7 +111,7 @@ A number of shared configurations are available to install and use with `commitl
 
 `commitlint` is considered stable and is used in various projects as development tool. 
 
-We indentify **ease of adoption** and **developer experience** as fields where there
+We identify **ease of adoption** and **developer experience** as fields where there
 is room and need for improvement. The items on the roadmap should enhance `commitlint` regarding those aspects.
 
 * [x] **Adoption**: Provide reusable Travis CI integration: `@commitlint/travis-cli` (https://github.com/marionebl/commitlint/releases/tag/v5.1.0)

--- a/docs/guides-local-setup.md
+++ b/docs/guides-local-setup.md
@@ -33,16 +33,16 @@ This allows us to add [git hooks](https://github.com/typicode/husky/blob/master/
 ```json
 {
   "scripts": {
-    "commitmsg": "commitlint -e $GIT_PARAMS"
+    "commitmsg": "commitlint -E GIT_PARAMS"
   }
 }
 ```
 
-Using `commitmsg` gives us exactly what we want: It is executed everytime a new commit is created. Passing husky's `$GIT_PARAMS` to `commitlint` via the `-e|--edit` flag directs it to the relevant edit file. `-e` defaults to `.git/COMMIT_EDITMSG`.
+Using `commitmsg` gives us exactly what we want: It is executed whenever a new commit is created. Passing husky's `GIT_PARAMS` to `commitlint` via the `-E|--env` flag directs it to the relevant edit file. `-e` would default to `.git/COMMIT_EDITMSG`.
 
 ## Test
 
-You can test the hook by simple commiting. You should see something like this if everything works.
+You can test the hook by simply committing. You should see something like this if everything works.
 
 ```bash
 git commit -m "foo: this will fail"

--- a/docs/guides-upgrade.md
+++ b/docs/guides-upgrade.md
@@ -20,7 +20,7 @@ npm install --save-dev @commitlint/cli @commitlint/config-conventional
 ```
 {
   "scripts": {
-    "commitmsg": "commitlint -x @commitlint/config-conventional -e $GIT_PARAMS"
+    "commitmsg": "commitlint -x @commitlint/config-conventional -E GIT_PARAMS"
   }
 }
 ```
@@ -47,7 +47,7 @@ npm install --save-dev @commitlint/cli @commitint/config-conventional
 ```
 {
   "scripts": {
-    "commitmsg": "commitlint -e $GIT_PARAMS"
+    "commitmsg": "commitlint -E GIT_PARAMS"
   }
 }
 ```

--- a/docs/reference-cli.md
+++ b/docs/reference-cli.md
@@ -3,16 +3,19 @@
 ```bash
 ❯ npx commitlint --help
 
-commitlint@4.2.0 - Lint your commit messages
+@commitlint@6.2.0 - Lint your commit messages
 
-  [input] reads from stdin if --edit, --from and --to are omitted
-  --color, -c            toggle colored output, defaults to: true
-  --cwd, -d              directory to execute in, defaults to: /Users/marneb/Documents/oss/commitlint
-  --edit, -e             read last commit message from the specified file or fallbacks to ./.git/COMMIT_EDITMSG
-  --extends, -x          array of shareable configurations to extend
-  --config, -g           path to a custom configuration
-  --from, -f             lower end of the commit range to lint; applies if edit=false
-  --to, -t               upper end of the commit range to lint; applies if edit=false
-  --quiet, -q            toggle console output
-  --parser-preset, -p    configuration preset to use for conventional-commits-parser
+[input] reads from stdin if --edit, --env, --from and --to are omitted
+--color, -c            toggle colored output, defaults to: true
+--config, -g           path to the config file
+--cwd, -d              directory to execute in, defaults to: $CD
+--edit, -e             read last commit message from the specified file or fallbacks to ./.git/COMMIT_EDITMSG
+--env, -E              check message in the file at path given by environment variable value
+--extends, -x          array of shareable configurations to extend
+--help, -h             display this help message
+--from, -f             lower end of the commit range to lint; applies if edit=false
+--parser-preset, -p    configuration preset to use for conventional-commits-parser
+--quiet, -q            toggle console output
+--to, -t               upper end of the commit range to lint; applies if edit=false
+--version, -v          display version information
 ```

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "lerna run build --stream --parallel --include-filtered-dependencies",
     "clean": "npx lerna clean --yes && npx lerna run clean --stream --parallel --include-filtered-dependencies",
     "commit": "node @commitlint/prompt-cli/cli.js",
-    "commitmsg": "node @commitlint/cli/lib/cli.js -e $GIT_PARAMS",
+    "commitmsg": "node @commitlint/cli/lib/cli.js -E GIT_PARAMS",
     "deps": "lerna run deps",
     "pkg": "lerna run pkg",
     "docs": "docsify serve docs",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add an argument `-E | --env` to the cli which accepts the name of an environment variable to be used for the path to the commit message file.

This also fixes some minor typos in the docs.

I haven't removed the `$GIT_PARAMS` handling as that should be a breaking change. However, it could be removed in a later version.

<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #319. 

In the newest/upcoming versions of Husky ([1.0.0-rc.1](https://github.com/typicode/husky/blob/dev/CHANGELOG.md#100-rc1)), the environment variable husky uses is renamed to `HUSKY_GIT_PARAMS` from `GIT_PARAMS`.

This means that the cross platform support for husky built into the CLI doesn't work for this and subsequent releases.

This implements the second fix suggested in https://github.com/marionebl/commitlint/issues/319#issue-318569827.

The alternative to this would to add a patch to normaliseEdit which detects HUSKY_GIT_PARAMS. However, that would be a hack which doesn't address the issue, that there is no cross-platform way to use environment variables in a command.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples
<!--- Provide examples of intended usage -->

```sh
echo "fix: fix something" > commit.txt
commitfile=commit.txt commitlint --env commitfile # Passes
```

```json
// package.json
...
"husky": {
    "hooks":{"pre-commit":"commitlint --env HUSKY_GIT_PARAMS"}
}
...
```

## How Has This Been Tested?
I have added two new tests, one covering a success and one covering a failure case.

Please note that I cannot get all of the tests to pass on my machine, specifically the husky integration tests. However, they pass on Travis.

I believe that this is because my windows username has a space in it, which breaks something due to the combination of husky, commitlint and the temporary directory, because I cannot reproduce this issue within my documents folder.

Note: the failure message for all of them is:
```
lerna ERR!   Error: Command failed: git commit -m "test: this should work"
lerna ERR!   husky > npm run -s commitmsg (node v8.9.4)
lerna ERR!
lerna ERR!   The filename, directory name, or volume label syntax is incorrect.
lerna ERR!
lerna ERR!   husky > commit-msg hook failed (add --no-verify to bypass)
```

Because of this I haven't ticked `All new and existing tests passed`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

EDIT: In first line, I put --edit. I meant --env.