### PR TITLE
fix: made lerna a peerDependency to avoid installing it multiple times

### DIFF
--- a/@commitlint/config-lerna-scopes/package.json
+++ b/@commitlint/config-lerna-scopes/package.json
@@ -39,14 +39,17 @@
     "url": "https://github.com/marionebl/commitlint/issues"
   },
   "homepage": "https://github.com/marionebl/commitlint#readme",
+  "peerDependencies": {
+    "lerna": "^2.9.0"
+  },
   "dependencies": {
-    "import-from": "2.1.0",
-    "lerna": "2.9.0"
+    "import-from": "2.1.0"
   },
   "devDependencies": {
     "@commitlint/test": "^7.0.0",
     "@commitlint/utils": "^7.0.0",
     "ava": "0.22.0",
+    "lerna": "2.9.0",
     "xo": "0.20.3"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`lerna@^2.9.0` should be a `peerDependency` (and for the purposes of the tests a `devDependency`) instead of a `dependency`.

## Motivation and Context

This will avoid situations in which multiple versions of `lerna` get installed into a monorepo and [it barfs when you try to run one of the commands (with "Incompatible local version of lerna detected!")](https://github.com/lerna/lerna/blob/2.x/src/Command.js#L271-L282) due to your `lerna.json#version` not matching the version which has decided to run. (This sometimes happens if `yarn` has decided to install your packages into a slightly weird folder structure and the version of `lerna` which is being picked up is not the version that you installed within your root `package.json`.)

## Usage examples

N/A

## How Has This Been Tested?

I ran `yarn test` at the root of the monorepo.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
