### PR TITLE
docs(readme): "conventional" not "convention"

### DIFF
--- a/@commitlint/config-conventional/README.md
+++ b/@commitlint/config-conventional/README.md
@@ -2,7 +2,7 @@
 
 # @commitlint/config-conventional
 
-Shareable `commitlint` config enforcing [convention commits](https://conventionalcommits.org/).
+Shareable `commitlint` config enforcing [conventional commits](https://conventionalcommits.org/).
 Use with [@commitlint/cli](../cli) and [@commitlint/prompt-cli](../prompt-cli).
 
 | :warning: |  |


### PR DESCRIPTION
## Description

The thing that `commitlint` enforces is properly called "conventional commits" rather than "convention commits". So, update a reference in the readme to use the term more correctly.

## Motivation and Context

Improves readability. Notice a glitch in docs, fix the glitch in docs.

## How Has This Been Tested?

[Viewed the resulting Markdown as rendered by GitHub](https://github.com/apetro/commitlint/blob/692101166cf7777c599d0a3e9680bc6143ef2f1b/%40commitlint/config-conventional/README.md).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. (Did not run tests locally, since this is a documentation-only change.)
