### PR TITLE
docs: add commitlint.io to related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ is room and need for improvement. The items on the roadmap should enhance `commi
 * [conventional-changelog](https://git.io/v18sw) – Generate a changelog from conventional commit history
 * [commitizen](https://git.io/vwTym) – Simple commit conventions for internet citizens
 * [create-semantic-module](https://git.io/vFjFg) – CLI for quickly integrating commitizen and commitlint in new or existing projects
-* [commitlint.io](https://commitlint.io/) - helps your project to ensures nice and tidy commit messages without needing any download or installation
+* [commitlint.io](https://github.com/tomasen/commitlintio) - helps your project to ensures nice and tidy commit messages without needing any download or installation
 
 ## License
 Copyright by @marionebl. All `commitlint` packages are released under the MIT license.

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ is room and need for improvement. The items on the roadmap should enhance `commi
 * [conventional-changelog](https://git.io/v18sw) – Generate a changelog from conventional commit history
 * [commitizen](https://git.io/vwTym) – Simple commit conventions for internet citizens
 * [create-semantic-module](https://git.io/vFjFg) – CLI for quickly integrating commitizen and commitlint in new or existing projects
+* [commitlint.io](https://commitlint.io/) - helps your project to ensures nice and tidy commit messages without needing any download or installation
 
 ## License
 Copyright by @marionebl. All `commitlint` packages are released under the MIT license.


### PR DESCRIPTION
applying for commitlint.io to be added to related projects

## Description
commitlint.io is a project based on commitlint package.

## Motivation and Context
commitlint.io provide another way to lint commit message for team members 
with a simple user interface and no need for any installation.
