### PR TITLE
docs: Change "angular" to "conventional"

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@
 ## Getting started
 
 ```sh
-# Install commitlint cli and angular config
+# Install commitlint cli and conventional config
 npm install --save-dev @commitlint/{config-conventional,cli}
 # For Windows:
 npm install --save-dev @commitlint/config-conventional @commitlint/cli
 
-# Configure commitlint to use angular config
+# Configure commitlint to use conventional config
 echo "module.exports = {extends: ['@commitlint/config-conventional']}" > commitlint.config.js
 ```
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In the README.md, the comments didn't line up with the commands. The commands are installing and setting up `config-conventional` but the comments mention `angular`. I updated the comments to align with the commands.
