### PR TITLE
refactor(lint): use invalid instead of missing for unknown rules

### DIFF
--- a/@commitlint/lint/src/index.js
+++ b/@commitlint/lint/src/index.js
@@ -35,7 +35,7 @@ export default async (message, rules = {}, opts = {}) => {
 	if (missing.length > 0) {
 		const names = Object.keys(implementations);
 		throw new RangeError(
-			`Found missing rule names: ${missing.join(
+			`Found invalid rule names: ${missing.join(
 				', '
 			)}. Supported rule names are: ${names.join(', ')}`
 		);

--- a/@commitlint/lint/src/index.test.js
+++ b/@commitlint/lint/src/index.test.js
@@ -59,7 +59,7 @@ test('throws for invalid rule names', async t => {
 		lint('foo', {foo: [2, 'always'], bar: [1, 'never']})
 	);
 
-	t.is(error.message.indexOf('Found missing rule names: foo, bar'), 0);
+	t.is(error.message.indexOf('Found invalid rule names: foo, bar'), 0);
 });
 
 test('throws for invalid rule config', async t => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixes #313

## ~~Motivation and Context~~
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## ~~Usage examples~~
<!--- Provide examples of intended usage -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

I've updated the tests which asserts if `Found invalid rule names: foo, bar` is returned.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
It's actually a minor refactor I think?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
