### PR TITLE
Fix/numeric subject case

### DIFF
--- a/@commitlint/ensure/src/case.js
+++ b/@commitlint/ensure/src/case.js
@@ -14,7 +14,7 @@ function ensureCase(raw = '', target = 'lowercase') {
 		.trim();
 	const transformed = toCase(input, target);
 
-	if (transformed === '') {
+	if (transformed === '' || transformed.match(/^\d/)) {
 		return true;
 	}
 
@@ -38,7 +38,7 @@ function toCase(input, target) {
 			return input.toUpperCase();
 		case 'sentence-case':
 		case 'sentencecase': {
-			const word = input.split(' ')[0];
+			const [word] = input.split(' ');
 			return `${toCase(word.charAt(0), 'upper-case')}${toCase(
 				word.slice(1),
 				'lower-case'

--- a/@commitlint/ensure/src/case.test.js
+++ b/@commitlint/ensure/src/case.test.js
@@ -291,3 +291,31 @@ test('false for `LOWERCASE on lowercase', t => {
 	const actual = ensure('`LOWERCASE', 'lowercase');
 	t.is(actual, false);
 });
+
+test('true for numeric on camel-case', t => {
+	t.true(ensure('1.0.0', 'camel-case'));
+});
+
+test('true for numeric on kebab-case', t => {
+	t.true(ensure('1.0.0', 'kebab-case'));
+});
+
+test('true for numeric on snake-case', t => {
+	t.true(ensure('1.0.0', 'snake-case'));
+});
+
+test('true for numeric on pascal-case', t => {
+	t.true(ensure('1.0.0', 'pascal-case'));
+});
+
+test('true for numeric on uppercase', t => {
+	t.true(ensure('1.0.0', 'uppercase'));
+});
+
+test('true for numeric on sentencecase', t => {
+	t.true(ensure('1.0.0', 'sentencecase'));
+});
+
+test('true for numeric on lowercase', t => {
+	t.true(ensure('1.0.0', 'lowercase'));
+});

--- a/@commitlint/rules/src/subject-case.js
+++ b/@commitlint/rules/src/subject-case.js
@@ -6,7 +6,7 @@ const negated = when => when === 'never';
 export default (parsed, when, value) => {
 	const {subject} = parsed;
 
-	if (typeof subject !== 'string') {
+	if (typeof subject !== 'string' || !subject.match(/^[a-z]/i)) {
 		return [true];
 	}
 

--- a/@commitlint/rules/src/subject-case.test.js
+++ b/@commitlint/rules/src/subject-case.test.js
@@ -4,6 +4,7 @@ import subjectCase from './subject-case';
 
 const messages = {
 	empty: 'test:\n',
+	numeric: 'test: 1.0.0',
 	lowercase: 'test: subject',
 	mixedcase: 'test: sUbJeCt',
 	uppercase: 'test: SUBJECT',
@@ -16,6 +17,7 @@ const messages = {
 
 const parsed = {
 	empty: parse(messages.empty),
+	numeric: parse(messages.numeric),
 	lowercase: parse(messages.lowercase),
 	mixedcase: parse(messages.mixedcase),
 	uppercase: parse(messages.uppercase),
@@ -322,5 +324,29 @@ test('with uppercase scope should fail for "never [uppercase, lowercase]"', asyn
 		'lowercase'
 	]);
 	const expected = false;
+	t.is(actual, expected);
+});
+
+test('with numeric subject should succeed for "never lowercase"', async t => {
+	const [actual] = subjectCase(await parsed.numeric, 'never', 'lowercase');
+	const expected = true;
+	t.is(actual, expected);
+});
+
+test('with numeric subject should succeed for "always lowercase"', async t => {
+	const [actual] = subjectCase(await parsed.numeric, 'always', 'lowercase');
+	const expected = true;
+	t.is(actual, expected);
+});
+
+test('with numeric subject should succeed for "never uppercase"', async t => {
+	const [actual] = subjectCase(await parsed.numeric, 'never', 'uppercase');
+	const expected = true;
+	t.is(actual, expected);
+});
+
+test('with numeric subject should succeed for "always uppercase"', async t => {
+	const [actual] = subjectCase(await parsed.numeric, 'always', 'uppercase');
+	const expected = true;
 	t.is(actual, expected);
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This fixes #438

## Motivation and Context
I've added edge case-ignores to both `@commitlint/rules`'s subject-case rule as well as `@commitlint/ensure`'s case. The reason for putting ignores in 2 places are these.

1. You said that we should ignore all characters not matching `/^[a-z]/i` from the case rules in general.
This was my initial thought of putting an ignore/exception into the `/ensure` package. Unfortunately, this conflicted with the [test of `LOWERCASE` (with backtick)](https://github.com/marionebl/commitlint/blob/master/%40commitlint/ensure/src/case.test.js#L291), so I had to change it to ignore `/^[0-9]/`.

2. In the subject case you can negate the rule
Due to the negation happening in the `/rules` package, and not `/ensure`, I had to also include the ignore here. I've tested it with both the `!a-z` as well as `0-9` ignore pattern, and here we actually could use the `!a-z` exclusion rule.

- `subjectCase('1.0.0', 'never', 'lowercase') === true`
- `subjectCase('1.0.0', 'always', 'lowercase') === true`

## Usage examples

```sh
$ printf "chore(release): 1.0.1 [skip ci]\n\n## [1.0.1](https://github.com/xmlking/ngx-starter-kit/compare/v1.0.0...v1.0.1) (2018-09-09)\n\n\n### Bug Fixes\n\n* **build:** now updating version ([2d913ea](https://github.com/xmlking/ngx-s
tarter-kit/commit/2d913ea))\n\n\n\n" | npx commitlint -x '@commitlint/config-conventional'
```

## How Has This Been Tested?
See motivation & context

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [x] All new and existing tests passed.
