### PR TITLE
fix(rules): include possible body offset in footer leading blank

### DIFF
--- a/@commitlint/rules/src/footer-leading-blank.js
+++ b/@commitlint/rules/src/footer-leading-blank.js
@@ -8,7 +8,10 @@ export default (parsed, when) => {
 	}
 
 	const negated = when === 'never';
-	const [leading] = toLines(parsed.raw).slice(toLines(parsed.body).length + 1);
+	const rawLines = toLines(parsed.raw);
+	const bodyLines = toLines(parsed.body);
+	const bodyOffset = bodyLines.length > 0 ? rawLines.indexOf(bodyLines[0]) : 1;
+	const [leading] = rawLines.slice(bodyLines.length + bodyOffset);
 
 	// Check if the first line of footer is empty
 	const succeeds = leading === '';

--- a/@commitlint/rules/src/footer-leading-blank.test.js
+++ b/@commitlint/rules/src/footer-leading-blank.test.js
@@ -11,7 +11,8 @@ const messages = {
 		'feat(new-parser): introduces a new parsing library\n\nBREAKING CHANGE: new library does not support foo-construct',
 	with: 'test: subject\nbody\n\nBREAKING CHANGE: something important',
 	withMulitLine:
-		'test: subject\nmulti\nline\nbody\n\nBREAKING CHANGE: something important'
+		'test: subject\nmulti\nline\nbody\n\nBREAKING CHANGE: something important',
+	withDoubleNewLine: 'fix: some issue\n\ndetailed explanation\n\ncloses #123'
 };
 
 const parsed = {
@@ -21,7 +22,8 @@ const parsed = {
 	without: parse(messages.without),
 	withoutBody: parse(messages.withoutBody),
 	with: parse(messages.with),
-	withMulitLine: parse(messages.withMulitLine)
+	withMulitLine: parse(messages.withMulitLine),
+	withDoubleNewLine: parse(messages.withDoubleNewLine)
 };
 
 test('with simple message should succeed for empty keyword', async t => {
@@ -140,6 +142,18 @@ test('with blank line before footer and multiline body should fail for "never"',
 
 test('with blank line before footer and multiline body should succeed for "always"', async t => {
 	const [actual] = footerLeadingBlank(await parsed.withMulitLine, 'always');
+	const expected = true;
+	t.is(actual, expected);
+});
+
+test('with double blank line before footer and double line in body should fail for "never"', async t => {
+	const [actual] = footerLeadingBlank(await parsed.withDoubleNewLine, 'never');
+	const expected = false;
+	t.is(actual, expected);
+});
+
+test('with double blank line before footer and double line in body should succeed for "always"', async t => {
+	const [actual] = footerLeadingBlank(await parsed.withDoubleNewLine, 'always');
 	const expected = true;
 	t.is(actual, expected);
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes #292 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

See [comment #426696523](https://github.com/marionebl/commitlint/issues/292#issuecomment-426696523)

## Usage examples
<!--- Provide examples of intended usage -->

```sh
echo 'docs(plugins): fix old docs\n\nConfig -> Plugins\n\ncloses #21' | npx commitlint -x '@commitlint/config-conventional'
```

```sh
echo 'feat: mail is now created by the supplied template function\n\nInstead of supplying all mail fields in the queue the information from the queue is given to a template function. This helps to prevent creating open mail servers that can be abused for spam. Also refactored the tests to a more traditional style.\n\nBREAKING CHANGE: The `template` option is required.' | npx commitlint -x '@commitlint/config-conventional'
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
