### PR TITLE
Ignoring merge commits with newline and extra text

### DIFF
--- a/@commitlint/is-ignored/src/index.js
+++ b/@commitlint/is-ignored/src/index.js
@@ -3,7 +3,7 @@ import semver from 'semver';
 const WILDCARDS = [
 	c =>
 		c.match(
-			/^((Merge pull request)|(Merge (.*?) into (.*?)|(Merge branch (.*?)))(?:\r?\n)*$)/
+			/^((Merge pull request)|(Merge (.*?) into (.*?)|(Merge branch (.*?)))(?:\r?\n)*$)/m
 		),
 	c => c.match(/^(R|r)evert (.*)/),
 	c => c.match(/^(fixup|squash)!/),

--- a/@commitlint/is-ignored/src/index.test.js
+++ b/@commitlint/is-ignored/src/index.test.js
@@ -61,6 +61,11 @@ test('should return true for merged PRs', t => {
 	t.true(isIgnored('Merge pull request #369'));
 });
 
+test('should return true for branch merges with newline characters and more characters after it', t => {
+	t.true(isIgnored("Merge branch 'ctrom-YarnBuild'\n "));
+	t.true(isIgnored("Merge branch 'ctrom-YarnBuild'\r\n # some comment"));
+});
+
 test('should return true for revert commits', t => {
 	t.true(
 		isIgnored(


### PR DESCRIPTION
## Description
If the merge commit has more characters after the new line it was not be ignored by commitlint.

## Motivation and Context
I had to do uncomfortable actions in order to avoid it.

## Usage examples
For instance, this message was not be ignored:

```
Merge branch 'master' of https://github.com/xxx/xxx
#
# It looks like you may be committing a merge.
# If this is not correct, please remove the file
#	.git/MERGE_HEAD
# and try again.


# Please enter the commit message for your changes. Lines starting
# with '#' will be ignored, and an empty message aborts the commit.
#
# On branch master
# Your branch and 'origin/master' have diverged,
# and have 2 and 1 different commits each, respectively.
#   (use "git pull" to merge the remote branch into yours)
#
# All conflicts fixed but you are still merging.
#
# Changes to be committed:
#	modified:   config/locale/en.po
#	modified:   config/locale/es.po
#	modified:   config/locale/messages.pot
#

```

## How Has This Been Tested?
I created a test

## Types of changes
Bug fix (non-breaking change which fixes an issue)