### PR TITLE
docs(format): update example code with new report structure

### DIFF
--- a/@commitlint/format/README.md
+++ b/@commitlint/format/README.md
@@ -13,29 +13,44 @@ npm install --save @commitlint/format
 ```js
 const format = require('@commitlint/format');
 
-format({
-  warnings: [
+const output = format({
+  valid: false,
+  errorCount: 1,
+  warningCount: 1,
+  results: [
     {
-      level: 0,
-      name: 'some-hint',
-      message: 'This will not show up as it has level 0'
-    },
-    {
-      level: 1,
-      name: 'some-warning',
-      message: 'This will show up yellow as it has level 1'
+      valid: false,
+      input: 'some: commit message',
+      errors: [
+        {
+          valid: false,
+          level: 2,
+          name: 'some-error',
+          message: 'This will show up red as it has level 2'
+        }
+      ],
+      warnings: [
+        {
+          valid: true,
+          level: 0,
+          name: 'some-hint',
+          message: 'This will not show up as it has level 0'
+        },
+        {
+          valid: false,
+          level: 1,
+          name: 'some-warning',
+          message: 'This will show up yellow as it has level 1'
+        }
+      ]
     }
-  ],
-  errors: [
-    {
-      level: 2,
-      name: 'some-error',
-      message: 'This will show up red as it has level 2'
-    }
-  ]
+  ]  
 }, {
   color: false
 });
+
+process.stdout.write(output);
+
 /* => [
   '✖   This will show up red as it has level 2 [some-error]',
   '    This will not show up as it has level 0 [some-hint]',
@@ -45,3 +60,4 @@ format({
 ```
 
 Consult [docs/api](http://marionebl.github.io/commitlint/#/reference-api) for comprehensive documentation.
+


### PR DESCRIPTION
## Description

The new formatters feature introduced the [new report-structure](https://github.com/marionebl/commitlint/issues/377#issuecomment-419658320). This structure is created [within the CLI](https://github.com/marionebl/commitlint/blob/master/%40commitlint/cli/src/cli.js#L152-L167) and [passed to the formatter](https://github.com/marionebl/commitlint/blob/master/%40commitlint/cli/src/cli.js#L169) to produce a nice string.

## Motivation and Context

I'd recon if people want to create their own formatter, they probably checkout the default `@commitlint/format`.

## ~~Usage examples~~

## ~~How Has This Been Tested?~~

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
