### PR TITLE
feat: add support for git submodules

### DIFF
--- a/@commitlint/read/src/index.js
+++ b/@commitlint/read/src/index.js
@@ -61,7 +61,7 @@ async function getEditFilePath(top, edit) {
 		} else {
 			const gitFile = await sander.readFile(dotgitPath, 'utf8');
 			const relativeGitPath = gitFile.replace('gitdir: ', '').replace('\n', '');
-			editFilePath = path.join(top, relativeGitPath, 'COMMIT_EDITMSG');
+			editFilePath = path.resolve(top, relativeGitPath, 'COMMIT_EDITMSG');
 		}
 	}
 

--- a/@commitlint/read/src/index.js
+++ b/@commitlint/read/src/index.js
@@ -41,11 +41,29 @@ async function getEditCommit(cwd, edit) {
 		throw new TypeError(`Could not find git root from ${cwd}`);
 	}
 
-	const editFilePath =
-		typeof edit === 'string'
-			? path.resolve(top, edit)
-			: path.join(top, '.git/COMMIT_EDITMSG');
+	const editFilePath = await getEditFilePath(top, edit);
 
 	const editFile = await sander.readFile(editFilePath);
 	return [`${editFile.toString('utf-8')}\n`];
+}
+
+// Get path to recently edited commit message file
+// (top: string, edit: any) => Promise<String>
+async function getEditFilePath(top, edit) {
+	let editFilePath;
+	if (typeof edit === 'string') {
+		editFilePath = path.resolve(top, edit);
+	} else {
+		const dotgitPath = path.join(top, '.git');
+		const dotgitStats = sander.lstatSync(dotgitPath);
+		if (dotgitStats.isDirectory()) {
+			editFilePath = path.join(top, '.git/COMMIT_EDITMSG');
+		} else {
+			const gitFile = await sander.readFile(dotgitPath, 'utf8');
+			const relativeGitPath = gitFile.replace('gitdir: ', '').replace('\n', '');
+			editFilePath = path.join(top, relativeGitPath, 'COMMIT_EDITMSG');
+		}
+	}
+
+	return editFilePath;
 }


### PR DESCRIPTION
Implements build-in support for linting the commits of _git sub modules_, which currently doesn't work because _sub modules_ don't have their own `.git` folder.

## Description
<!--- Describe your changes in detail -->
I updated the read module to determine if it is running from a git sub module or not and find the `COMMIT_EDITMSG` accordingly. It still uses `edit` argument if present, otherwise it looks at `.git` and checks whether it is a directory (if it is, look for the `COMMIT_EDITMSG` as before) or a file, in which case it reads the file to figure out where the `COMMIT_EDITMSG` can be found.

Comments on my implementation are welcome, I'm happy to change it if needed 🙂 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required in order to support linting the commits of git sub modules.

<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #448

## Usage examples
n/a

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tests are missing from this PR (at least for now) as it requires an update to the [@commitlint/test](https://github.com/marionebl/commitlint/tree/master/%40packages/test) package (support for sub modules in the `git` helper has to be added). However, I did create a test locally with a rough outline of what the update to the [@commitlint/test](https://github.com/marionebl/commitlint/tree/master/%40packages/test) might look like. You can find the required changes in this [gist](https://gist.github.com/ericcornelissen/cdc4cbaeae5f75b749c2893ce21455fc), simply checkout on this branch and replace the local files with the two in the gist and you can test the new feature.

The reason I opened this PR first is because I wanted to be sure this would be included before updating the [@commitlint/test](https://github.com/marionebl/commitlint/tree/master/%40packages/test) code and adding something that wasn't really needed...

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes. (see "How Has This Been Tested?" for details)
- [x] All new and existing tests passed.
