### PR TITLE
docs: point first-time users to docs

### DIFF
--- a/@commitlint/format/src/index.js
+++ b/@commitlint/format/src/index.js
@@ -62,7 +62,8 @@ function formatResult(result = {}, options = {}) {
 	const decoration = enabled ? chalk[color](sign) : sign;
 	const summary = `${decoration}   found ${errors.length} problems, ${
 		warnings.length
-	} warnings`;
+	} warnings\n    Need help? -> https://github.com/marionebl/commitlint#what-is-commitlint
+	`;
 	return [...problems, enabled ? chalk.bold(summary) : summary];
 }
 

--- a/@commitlint/format/src/index.js
+++ b/@commitlint/format/src/index.js
@@ -62,8 +62,7 @@ function formatResult(result = {}, options = {}) {
 	const decoration = enabled ? chalk[color](sign) : sign;
 	const summary = `${decoration}   found ${errors.length} problems, ${
 		warnings.length
-	} warnings\n    Need help? -> https://github.com/marionebl/commitlint#what-is-commitlint
-	`;
+	} warnings \n    (Need help? -> https://github.com/marionebl/commitlint#what-is-commitlint)`;
 	return [...problems, enabled ? chalk.bold(summary) : summary];
 }
 

--- a/@commitlint/format/src/index.test.js
+++ b/@commitlint/format/src/index.test.js
@@ -3,7 +3,11 @@ import chalk from 'chalk';
 import includes from 'lodash.includes';
 import format from '.';
 
-const ok = chalk.bold(`${chalk.green('✔')}   found 0 problems, 0 warnings`);
+const ok = chalk.bold(
+	`${chalk.green(
+		'✔'
+	)}   found 0 problems, 0 warnings \n    (Need help? -> https://github.com/marionebl/commitlint#what-is-commitlint)`
+);
 
 test('does nothing without arguments', t => {
 	const actual = format();

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
 
 ## Contents
 
+* [What is commitlint](#what-is-commitlint)
+  * [Benefits using commitlint](#benefits-using-commitlint)
 * [Getting started](#getting-started)
 * [CLI](#cli)
 * [Config](#config)
@@ -34,6 +36,43 @@
   * [Publishing a release](#publishing-a-release)
 
 * * *
+
+## What is commitlint
+Commitlint is a linter which is linting your commit-messages according to the [conventional commit format](https://conventionalcommits.org).
+
+In general the pattern mostly looks like this:
+```sh
+type(scope?): subject  #scope is optional
+```
+Real world examples can look like this:
+```
+chore: run tests on travis ci
+```
+```
+fix(server): send cors headers
+```
+```
+feat(blog): add comment section
+```
+Common types according to [commitlint-config-conventional (based on the the Angular convention)](https://github.com/marionebl/commitlint/tree/master/%40commitlint/config-conventional#type-enum) can be:
+- build
+- ci
+- chore
+- docs
+- feat
+- fix
+- perf
+- refactor
+- revert
+- style
+- test
+
+These can be modified by your own configuration.
+
+### Benefits using commitlint
+- [Why Use Conventional Commits?](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#why-use-conventional-commits)
+- ["The perks of committing with conventions" (Talk slides)](https://slides.com/marionebl/the-perks-of-committing-with-conventions#/)
+
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 * * *
 
 ## What is commitlint
-Commitlint is a linter which is linting your commit-messages according to the [conventional commit format](https://conventionalcommits.org).
+commitlint checks if your commit messages meet the [conventional commit format](https://conventionalcommits.org).
 
 In general the pattern mostly looks like this:
 ```sh

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Common types according to [commitlint-config-conventional (based on the the Angu
 - style
 - test
 
-These can be modified by your own configuration.
+These can be modified by [your own configuration](#config).
 
 ### Benefits using commitlint
 - [Why Use Conventional Commits?](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#why-use-conventional-commits)


### PR DESCRIPTION
## Description
Should fix #471  

## Usage examples
New output message looks liek this:
```sh
✖   subject may not be empty [subject-empty]
✖   type may not be empty [type-empty]
✖   found 2 problems, 0 warnings
    (Need help? -> https://github.com/marionebl/commitlint#what-is-commitlint)
```


## How Has This Been Tested?
Updated tests for `format`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
   I think master is still broken for now. Need to check this in another PR.
