### PR TITLE
refactor(cli): add fallback with husky git params to deprecation handling

### DIFF
--- a/@commitlint/cli/src/cli.js
+++ b/@commitlint/cli/src/cli.js
@@ -228,16 +228,24 @@ function getEditValue(flags) {
 	// This does not work properly with win32 systems, where env variable declarations
 	// use a different syntax
 	// See https://github.com/marionebl/commitlint/issues/103 for details
-	// This has been superceded by the `-E HUSKY_GIT_PARAMS` / `-E HUSKY_GIT_PARAMS`
-	if (edit === '$HUSKY_GIT_PARAMS' || edit === '%HUSKY_GIT_PARAMS%') {
+	// This has been superceded by the `-E GIT_PARAMS` / `-E HUSKY_GIT_PARAMS`
+	const isGitParams = edit === '$GIT_PARAMS' || edit === '%GIT_PARAMS%';
+	const isHuskyParams =
+		edit === '$HUSKY_GIT_PARAMS' || edit === '%HUSKY_GIT_PARAMS%';
+
+	if (isGitParams || isHuskyParams) {
 		console.warn(`Using environment variable syntax (${edit}) in -e |\
 --edit is deprecated. Use '{-E|--env} HUSKY_GIT_PARAMS instead'`);
-		if (!('HUSKY_GIT_PARAMS' in process.env)) {
-			throw new Error(
-				`Received ${edit} as value for -e | --edit, but HUSKY_GIT_PARAMS is not available globally.`
-			);
+
+		if (isGitParams && 'GIT_PARAMS' in process.env) {
+			return process.env.GIT_PARAMS;
 		}
-		return process.env.HUSKY_GIT_PARAMS;
+		if ('HUSKY_GIT_PARAMS' in process.env) {
+			return process.env.HUSKY_GIT_PARAMS;
+		}
+		throw new Error(
+			`Received ${edit} as value for -e | --edit, but GIT_PARAMS or HUSKY_GIT_PARAMS are not available globally.`
+		);
 	}
 	return edit;
 }

--- a/@commitlint/cli/src/cli.js
+++ b/@commitlint/cli/src/cli.js
@@ -224,20 +224,20 @@ function getEditValue(flags) {
 	if (typeof edit === 'boolean') {
 		return edit;
 	}
-	// The recommended method to specify -e with husky was `commitlint -e $GIT_PARAMS`
+	// The recommended method to specify -e with husky was `commitlint -e $HUSKY_GIT_PARAMS`
 	// This does not work properly with win32 systems, where env variable declarations
 	// use a different syntax
 	// See https://github.com/marionebl/commitlint/issues/103 for details
-	// This has been superceded by the `-E GIT_PARAMS` / `-E HUSKY_GIT_PARAMS`
-	if (edit === '$GIT_PARAMS' || edit === '%GIT_PARAMS%') {
+	// This has been superceded by the `-E HUSKY_GIT_PARAMS` / `-E HUSKY_GIT_PARAMS`
+	if (edit === '$HUSKY_GIT_PARAMS' || edit === '%HUSKY_GIT_PARAMS%') {
 		console.warn(`Using environment variable syntax (${edit}) in -e |\
---edit is deprecated. Use '{-E|--env} GIT_PARAMS instead'`);
-		if (!('GIT_PARAMS' in process.env)) {
+--edit is deprecated. Use '{-E|--env} HUSKY_GIT_PARAMS instead'`);
+		if (!('HUSKY_GIT_PARAMS' in process.env)) {
 			throw new Error(
-				`Received ${edit} as value for -e | --edit, but GIT_PARAMS is not available globally.`
+				`Received ${edit} as value for -e | --edit, but HUSKY_GIT_PARAMS is not available globally.`
 			);
 		}
-		return process.env.GIT_PARAMS;
+		return process.env.HUSKY_GIT_PARAMS;
 	}
 	return edit;
 }

--- a/@commitlint/cli/src/cli.test.js
+++ b/@commitlint/cli/src/cli.test.js
@@ -109,18 +109,24 @@ test('should work with husky commitmsg hook in sub packages', async () => {
 	await execa('git', ['commit', '-m', '"test: this should work"'], {cwd});
 });
 
-test('should work with husky via commitlint -e $GIT_PARAMS', async () => {
+test('should work with husky via commitlint -e $HUSKY_GIT_PARAMS', async () => {
 	const cwd = await git.bootstrap('fixtures/husky/integration');
-	await writePkg({scripts: {commitmsg: `'${bin}' -e $GIT_PARAMS`}}, {cwd});
+	await writePkg(
+		{scripts: {commitmsg: `'${bin}' -e $HUSKY_GIT_PARAMS`}},
+		{cwd}
+	);
 
 	await execa('npm', ['install'], {cwd});
 	await execa('git', ['add', 'package.json'], {cwd});
 	await execa('git', ['commit', '-m', '"test: this should work"'], {cwd});
 });
 
-test('should work with husky via commitlint -e %GIT_PARAMS%', async () => {
+test('should work with husky via commitlint -e %HUSKY_GIT_PARAMS%', async () => {
 	const cwd = await git.bootstrap('fixtures/husky/integration');
-	await writePkg({scripts: {commitmsg: `'${bin}' -e %GIT_PARAMS%`}}, {cwd});
+	await writePkg(
+		{scripts: {commitmsg: `'${bin}' -e %HUSKY_GIT_PARAMS%`}},
+		{cwd}
+	);
 
 	await execa('npm', ['install'], {cwd});
 	await execa('git', ['add', 'package.json'], {cwd});

--- a/@commitlint/cli/src/cli.test.js
+++ b/@commitlint/cli/src/cli.test.js
@@ -109,6 +109,24 @@ test('should work with husky commitmsg hook in sub packages', async () => {
 	await execa('git', ['commit', '-m', '"test: this should work"'], {cwd});
 });
 
+test('should work with husky via commitlint -e $GIT_PARAMS', async () => {
+	const cwd = await git.bootstrap('fixtures/husky/integration');
+	await writePkg({scripts: {commitmsg: `'${bin}' -e $GIT_PARAMS`}}, {cwd});
+
+	await execa('npm', ['install'], {cwd});
+	await execa('git', ['add', 'package.json'], {cwd});
+	await execa('git', ['commit', '-m', '"test: this should work"'], {cwd});
+});
+
+test('should work with husky via commitlint -e %GIT_PARAMS%', async () => {
+	const cwd = await git.bootstrap('fixtures/husky/integration');
+	await writePkg({scripts: {commitmsg: `'${bin}' -e %GIT_PARAMS%`}}, {cwd});
+
+	await execa('npm', ['install'], {cwd});
+	await execa('git', ['add', 'package.json'], {cwd});
+	await execa('git', ['commit', '-m', '"test: this should work"'], {cwd});
+});
+
 test('should work with husky via commitlint -e $HUSKY_GIT_PARAMS', async () => {
 	const cwd = await git.bootstrap('fixtures/husky/integration');
 	await writePkg(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This adds `HUSKY_GIT_PARAMS` fallback to the existing `GIT_PARAMS` deprecation handling, as [described in their docs](https://github.com/typicode/husky#upgrading-from-014).

> Note, I've created two solutions for this problem. This is one, and the [other one is to remove (and later reimplement)](https://github.com/marionebl/commitlint/pull/499). Please pick one, I'll close the other.

> Edit, I prefer this one since it's now backward compatible.

## ~~Motivation and Context~~
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## ~~Usage examples~~

## ~~How Has This Been Tested?~~
<!--- Please describe in detail how you tested your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [X] All new and existing tests passed.
