### PR TITLE
refactor(cli): remove old broken husky params fallback

### DIFF
--- a/@commitlint/cli/src/cli.js
+++ b/@commitlint/cli/src/cli.js
@@ -224,21 +224,6 @@ function getEditValue(flags) {
 	if (typeof edit === 'boolean') {
 		return edit;
 	}
-	// The recommended method to specify -e with husky was `commitlint -e $GIT_PARAMS`
-	// This does not work properly with win32 systems, where env variable declarations
-	// use a different syntax
-	// See https://github.com/marionebl/commitlint/issues/103 for details
-	// This has been superceded by the `-E GIT_PARAMS` / `-E HUSKY_GIT_PARAMS`
-	if (edit === '$GIT_PARAMS' || edit === '%GIT_PARAMS%') {
-		console.warn(`Using environment variable syntax (${edit}) in -e |\
---edit is deprecated. Use '{-E|--env} GIT_PARAMS instead'`);
-		if (!('GIT_PARAMS' in process.env)) {
-			throw new Error(
-				`Received ${edit} as value for -e | --edit, but GIT_PARAMS is not available globally.`
-			);
-		}
-		return process.env.GIT_PARAMS;
-	}
 	return edit;
 }
 

--- a/@commitlint/cli/src/cli.test.js
+++ b/@commitlint/cli/src/cli.test.js
@@ -109,24 +109,6 @@ test('should work with husky commitmsg hook in sub packages', async () => {
 	await execa('git', ['commit', '-m', '"test: this should work"'], {cwd});
 });
 
-test('should work with husky via commitlint -e $GIT_PARAMS', async () => {
-	const cwd = await git.bootstrap('fixtures/husky/integration');
-	await writePkg({scripts: {commitmsg: `'${bin}' -e $GIT_PARAMS`}}, {cwd});
-
-	await execa('npm', ['install'], {cwd});
-	await execa('git', ['add', 'package.json'], {cwd});
-	await execa('git', ['commit', '-m', '"test: this should work"'], {cwd});
-});
-
-test('should work with husky via commitlint -e %GIT_PARAMS%', async () => {
-	const cwd = await git.bootstrap('fixtures/husky/integration');
-	await writePkg({scripts: {commitmsg: `'${bin}' -e %GIT_PARAMS%`}}, {cwd});
-
-	await execa('npm', ['install'], {cwd});
-	await execa('git', ['add', 'package.json'], {cwd});
-	await execa('git', ['commit', '-m', '"test: this should work"'], {cwd});
-});
-
 test('should allow reading of environment variables for edit file, succeeding if valid', async t => {
 	const cwd = await git.bootstrap();
 	await sander.writeFile(cwd, 'commit-msg-file', 'foo');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This removes the `commitlint -e $GIT_PARAMS` part from commitlint, because this is now failing and probably incompatible with Husky.

> Note, I've created two solutions for this problem. This is one, and the [other one is to rename](https://github.com/marionebl/commitlint/pull/498). Please pick one, I'll close the other.

## ~~Motivation and Context~~
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## ~~Usage examples~~

## ~~How Has This Been Tested?~~
<!--- Please describe in detail how you tested your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
