### PR TITLE
fix(cli): avoid truncated output on macOS

### DIFF
--- a/@commitlint/cli/src/cli.js
+++ b/@commitlint/cli/src/cli.js
@@ -171,7 +171,7 @@ async function main(options) {
 	const output = format(report, {color: flags.color});
 
 	if (!flags.quiet) {
-		process.stdout.write(output);
+		console.log(output);
 	}
 
 	if (!report.valid) {


### PR DESCRIPTION
Use console.log() instead of process.stdout.write() will avoid potential output truncation on macOS.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Replace usage of `process.stdout.write()` with `console.log()`.

## Motivation and Context

I noticed this first when using `commitlint` with `husky`:

![image](https://user-images.githubusercontent.com/924465/49129842-2d0a7680-f286-11e8-8214-2f14efb688e1.png)

I confirmed this wasn't a `husky`-specific issue by simply piping STDIN:

![image](https://user-images.githubusercontent.com/924465/49129886-562b0700-f286-11e8-8e29-eff6167c72ff.png)

On macOS, if output is truncated--the `node` process quits before the STDOUT stream has ended--we will see a `%`.

I then confirmed this happens in `master`:

![image](https://user-images.githubusercontent.com/924465/49129977-9b4f3900-f286-11e8-8154-cb2012a4edf7.png)

I went and looked for the message in the codebase, and found it was output via a call to `process.stdout.write()`, which was the likely culprit.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

"Works on my machine":

![image](https://user-images.githubusercontent.com/924465/49130162-655e8480-f287-11e8-832a-a265568461e3.png)

I *could* write a test that asserts output isn't truncated, but I *couldn't* be sure that it wouldn't be flaky.

I couldn't find a reason why `process.stdout.write()` was used in the first place, which is the main risk with merging this.  That said, it *seems* relatively safe to me.  You be the judge.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
