### PR TITLE
fix(cli): cleanup message for input with no config

### DIFF
--- a/@commitlint/cli/src/cli.js
+++ b/@commitlint/cli/src/cli.js
@@ -151,6 +151,14 @@ async function main(options) {
 	);
 
 	if (Object.keys(loaded.rules).length === 0) {
+		let input = '';
+
+		if (results.length !== 0) {
+			const originalInput = results[0].input;
+			input = originalInput;
+			results.pop();
+		}
+
 		results.push({
 			valid: false,
 			errors: [
@@ -166,7 +174,7 @@ async function main(options) {
 				}
 			],
 			warnings: [],
-			input: ''
+			input
 		});
 	}
 

--- a/@commitlint/cli/src/cli.js
+++ b/@commitlint/cli/src/cli.js
@@ -156,10 +156,9 @@ async function main(options) {
 		if (results.length !== 0) {
 			const originalInput = results[0].input;
 			input = originalInput;
-			results.pop();
 		}
 
-		results.push({
+		results.splice(0, results.length, {
 			valid: false,
 			errors: [
 				{

--- a/@commitlint/format/src/index.js
+++ b/@commitlint/format/src/index.js
@@ -31,7 +31,7 @@ function formatInput(result = {}, options = {}) {
 
 	const sign = '⧗';
 	const decoration = enabled ? chalk.gray(sign) : sign;
-	const commitText = errors.length > 0 ? `\n${input}\n` : input.split('\n')[0];
+	const commitText = errors.length > 0 ? input : input.split('\n')[0];
 
 	const decoratedInput = enabled ? chalk.bold(commitText) : commitText;
 


### PR DESCRIPTION
## Description
Avoid confusing duplication of result message if input and empty config.  
As discussed on slack.

## Usage examples
Somewhere outside of the repo try:
```sh
echo "null " | node commitlint/@commitlint/cli/lib/cli.js --config commitlint/@commitlint/cli/fixtures/empty/commitlint.config.js
```

Result before:
```
⧗   input: null
✔   found 0 problems, 0 warnings
    (Need help? -> https://github.com/marionebl/commitlint#what-is-commitlint)
✖   Please add rules to your `commitlint.config.js`
    - Getting started guide: https://git.io/fpUzJ
    - Example config: https://git.io/fpUzm [empty-rules]
✖   found 1 problems, 0 warnings
    (Need help? -> https://github.com/marionebl/commitlint#what-is-commitlint)
```

Result after:
```
⧗   input:
null

✖   Please add rules to your `commitlint.config.js`
    - Getting started guide: https://git.io/fpUzJ
    - Example config: https://git.io/fpUzm [empty-rules]
✖   found 1 problems, 0 warnings
    (Need help? -> https://github.com/marionebl/commitlint#what-is-commitlint)
```

## How Has This Been Tested?
Has not.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
