### PR TITLE
fix(cli): avoid linebreak in empty input

### DIFF
--- a/@commitlint/cli/src/cli.js
+++ b/@commitlint/cli/src/cli.js
@@ -123,6 +123,7 @@ async function main(options) {
 
 	const messages = (Array.isArray(input) ? input : [input])
 		.filter(message => typeof message === 'string')
+		.filter(message => message.trim() !== '')
 		.filter(Boolean);
 
 	if (messages.length === 0 && !checkFromRepository(flags)) {


### PR DESCRIPTION
## Description
[As discussed](https://github.com/marionebl/commitlint/issues/511#issuecomment-447680527) we can trim the empty input to invalidate an input which per default comes as `\n`.

## Motivation and Context
#511

## How Has This Been Tested?
I need help here. [We have this test](https://github.com/marionebl/commitlint/blob/master/%40commitlint/cli/src/cli.test.js#L23) but I'm not sure what is being tested here. It worked before and still works...

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
