### PR TITLE
fix slash in scope #291

### DIFF
--- a/@commitlint/ensure/src/case.js
+++ b/@commitlint/ensure/src/case.js
@@ -8,7 +8,11 @@ function ensureCase(raw = '', target = 'lowercase') {
 	const input = String(raw)
 		.replace(/`.*?`|".*?"|'.*?'/g, '')
 		.trim();
-	const transformed = toCase(input, target);
+	
+	const delimiters = /(\/|\\)/g;
+	const transformed = input.split(delimiters)
+		.map(segment => delimiters.test(segment) ? segment : toCase(segment, target))
+		.join('');
 
 	if (transformed === '' || transformed.match(/^\d/)) {
 		return true;

--- a/@commitlint/ensure/src/case.test.js
+++ b/@commitlint/ensure/src/case.test.js
@@ -110,6 +110,11 @@ test('true for * on pascal-case', t => {
 	t.is(actual, true);
 });
 
+test('true for Modules/Graph on pascal-case', t => {
+	const actual = ensure('Modules/Graph', 'pascal-case');
+	t.is(actual, true);
+});
+
 test('true for * on start-case', t => {
 	const actual = ensure('*', 'start-case');
 	t.is(actual, true);

--- a/@commitlint/rules/src/scope-case.js
+++ b/@commitlint/rules/src/scope-case.js
@@ -21,7 +21,7 @@ export default (parsed, when, value) => {
 	});
 
 	const result = checks.some(check => {
-		const r = ensure.case(scope, check.case); // Type "Modules/Graph" creates false here
+		const r = ensure.case(scope, check.case);
 		return negated(check.when) ? !r : r;
 	});
 

--- a/@commitlint/rules/src/scope-case.js
+++ b/@commitlint/rules/src/scope-case.js
@@ -21,7 +21,7 @@ export default (parsed, when, value) => {
 	});
 
 	const result = checks.some(check => {
-		const r = ensure.case(scope, check.case);
+		const r = ensure.case(scope, check.case); // Type "Modules/Graph" creates false here
 		return negated(check.when) ? !r : r;
 	});
 


### PR DESCRIPTION
Tried to narrow this down.

## Description
Using this scope `Modules\Graph` with the `pascal-case` rule fails.  

In `@commitlint/rules/src/scope-case.js`:  
`const r = ensure.case(scope, check.case);` this returns false for such case.

First I only try to add a test-case which would be suitable for this situation. If this is correct we could chech where a fix in `case.js` coudl be implemented.

Currently thsi test fails:
```
✖ case › true for Modules/Graph on pascal-case
```