### PR TITLE
fix: `sentence-case` doesn't allow upper-case characters in first word

### DIFF
--- a/@commitlint/ensure/src/case.js
+++ b/@commitlint/ensure/src/case.js
@@ -33,13 +33,8 @@ function toCase(input, target) {
 		case 'uppercase':
 			return input.toUpperCase();
 		case 'sentence-case':
-		case 'sentencecase': {
-			const [word] = input.split(' ');
-			return `${toCase(word.charAt(0), 'upper-case')}${toCase(
-				word.slice(1),
-				'lower-case'
-			)}${input.slice(word.length)}`;
-		}
+		case 'sentencecase':
+			return input.charAt(0).toUpperCase() + input.slice(1);
 		case 'lower-case':
 		case 'lowercase':
 		case 'lowerCase': // Backwards compat config-angular v4

--- a/@commitlint/ensure/src/case.test.js
+++ b/@commitlint/ensure/src/case.test.js
@@ -61,16 +61,16 @@ test('false for lowercase on sentencecase', t => {
 	t.is(ensure('sentence case', 'sentence-case'), false);
 });
 
-test('false for UPPERCASE on sentencecase', t => {
-	t.is(ensure('UPPERCASE', 'sentence-case'), false);
+test('true for UPPERCASE on sentencecase', t => {
+	t.is(ensure('UPPERCASE', 'sentence-case'), true);
 });
 
 test('true for Start Case on sentencecase', t => {
 	t.is(ensure('Start Case', 'sentence-case'), true);
 });
 
-test('false for PascalCase on sentencecase', t => {
-	t.is(ensure('PascalCase', 'sentence-case'), false);
+test('true for PascalCase on sentencecase', t => {
+	t.is(ensure('PascalCase', 'sentence-case'), true);
 });
 
 test('false for kebab-case on sentencecase', t => {


### PR DESCRIPTION
## Description

This changes the `sentence-case` rule to also accept upper-case characters in the first word, allowing the use of acronyms (e.g. "HTML", "JSX") and words which include upper-case characters (e.g. "JavaScript") at the beginning of a `sentence-case` input.

## Motivation and Context

In a project, we're using ESLint style commit messages with set up `sentence-case` rule for the commit message subject. When authoring a commit message, the commit would be rejected from time to time due to use of a word with upper-case characters (or an acronym) at the beginning of the subject input.

According to sentence case inputs, I think the only `commitlint` "sentence-case" rule validation should be that the first character of the first word is capitalized. Related issue: #211.

## Usage examples

```js
// commitlint.config.js
module.exports = {
  rules: {
    'subject-case': [2, 'always', ['sentence-case']],
    'type-enum': [2, 'always', ['Fix', 'Update', 'New', 'Breaking', 'Docs', 'Build', 'Upgrade', 'Chore']],
  },
};
```

```sh
echo "Fix: VAT note not properly displayed" | commitlint # passes
echo "Upgrade: ESLint dev dependency" | commitlint # passes
```

## How has this been tested?

Tested with example inputs in Node.js console and a test project.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have ~~added~~updated tests to cover my changes.
- [x] All new and existing tests passed.