### PR TITLE
fix: move lodash to dependencies

### DIFF
--- a/@commitlint/lint/package.json
+++ b/@commitlint/lint/package.json
@@ -69,7 +69,6 @@
     "cross-env": "5.1.1",
     "execa": "0.9.0",
     "globby": "8.0.1",
-    "lodash": "4.17.11",
     "rimraf": "2.6.1",
     "xo": "0.20.3"
   },
@@ -77,6 +76,7 @@
     "@commitlint/is-ignored": "^7.3.1",
     "@commitlint/parse": "^7.3.1",
     "@commitlint/rules": "^7.3.1",
-    "babel-runtime": "^6.23.0"
+    "babel-runtime": "^6.23.0",
+    "lodash": "4.17.11"
   }
 }


### PR DESCRIPTION
`lodash` is not a devDependency it is used at runtime.