### PR TITLE
fix: add white space so the link open properly

### DIFF
--- a/@commitlint/format/src/index.js
+++ b/@commitlint/format/src/index.js
@@ -62,7 +62,7 @@ function formatResult(result = {}, options = {}) {
 	const decoration = enabled ? chalk[color](sign) : sign;
 	const summary = `${decoration}   found ${errors.length} problems, ${
 		warnings.length
-	} warnings \n    (Need help? -> https://github.com/marionebl/commitlint#what-is-commitlint)\n\n`;
+	} warnings \n    (Need help? -> https://github.com/marionebl/commitlint#what-is-commitlint )\n\n`;
 	return [...problems, enabled ? chalk.bold(summary) : summary];
 }
 

--- a/@commitlint/format/src/index.test.js
+++ b/@commitlint/format/src/index.test.js
@@ -6,7 +6,7 @@ import format from '.';
 const ok = chalk.bold(
 	`${chalk.green(
 		'✔'
-	)}   found 0 problems, 0 warnings \n    (Need help? -> https://github.com/marionebl/commitlint#what-is-commitlint)\n\n`
+	)}   found 0 problems, 0 warnings \n    (Need help? -> https://github.com/marionebl/commitlint#what-is-commitlint )\n\n`
 );
 
 test('does nothing without arguments', t => {


### PR DESCRIPTION
When clicking CRTL+open on the link it takes the ")" with the link to the browser.


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

