### PR TITLE
feat(rule-header-length): show current header length

### DIFF
--- a/@commitlint/rules/src/header-max-length.js
+++ b/@commitlint/rules/src/header-max-length.js
@@ -3,6 +3,8 @@ import {maxLength} from '@commitlint/ensure';
 export default (parsed, when, value) => {
 	return [
 		maxLength(parsed.header, value),
-		`header must not be longer than ${value} characters`
+		`header must not be longer than ${value} characters, current length is ${
+			parsed.header.length
+		}`
 	];
 };

--- a/@commitlint/rules/src/header-min-length.js
+++ b/@commitlint/rules/src/header-min-length.js
@@ -3,6 +3,8 @@ import {minLength} from '@commitlint/ensure';
 export default (parsed, when, value) => {
 	return [
 		minLength(parsed.header, value),
-		`header must not be shorter than ${value} characters`
+		`header must not be shorter than ${value} characters, current length is ${
+			parsed.header.length
+		}`
 	];
 };


### PR DESCRIPTION
show current header length, when lint error.